### PR TITLE
fix: Auto-configuration 버그 수정 및 Native Image 힌트 개선

### DIFF
--- a/querydsl-ktx-spring-boot/src/main/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfiguration.kt
+++ b/querydsl-ktx-spring-boot/src/main/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfiguration.kt
@@ -5,12 +5,14 @@ import jakarta.persistence.EntityManager
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ImportRuntimeHints
 
 @AutoConfiguration(after = [HibernateJpaAutoConfiguration::class])
 @ConditionalOnClass(JPAQueryFactory::class)
+@ConditionalOnSingleCandidate(EntityManager::class)
 @ImportRuntimeHints(QuerydslKtxRuntimeHints::class)
 class QuerydslKtxAutoConfiguration {
 

--- a/querydsl-ktx-spring-boot/src/main/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxRuntimeHints.kt
+++ b/querydsl-ktx-spring-boot/src/main/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxRuntimeHints.kt
@@ -24,11 +24,13 @@ class QuerydslKtxRuntimeHints : RuntimeHintsRegistrar {
                 com.querydsl.ktx.support.QuerydslSupport::class.java,
                 MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
                 MemberCategory.INVOKE_PUBLIC_METHODS,
+                MemberCategory.INVOKE_DECLARED_METHODS,
             )
             .registerType(
                 com.querydsl.ktx.support.QuerydslRepository::class.java,
                 MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
                 MemberCategory.INVOKE_PUBLIC_METHODS,
+                MemberCategory.INVOKE_DECLARED_METHODS,
             )
     }
 }

--- a/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationTest.kt
+++ b/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationTest.kt
@@ -49,6 +49,16 @@ class QuerydslKtxAutoConfigurationTest {
             }
     }
 
+    @Test
+    fun `does not register when multiple EntityManager beans exist`() {
+        contextRunner
+            .withBean("em1", EntityManager::class.java, { Mockito.mock(EntityManager::class.java) })
+            .withBean("em2", EntityManager::class.java, { Mockito.mock(EntityManager::class.java) })
+            .run { context ->
+                assertTrue(!context.containsBean("jpaQueryFactory"))
+            }
+    }
+
     @Configuration(proxyBeanMethods = false)
     internal class CustomJpaQueryFactoryConfig {
         @Bean

--- a/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxRuntimeHintsTest.kt
+++ b/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxRuntimeHintsTest.kt
@@ -2,6 +2,7 @@ package com.querydsl.ktx.autoconfigure
 
 import com.querydsl.ktx.support.QuerydslRepository
 import com.querydsl.ktx.support.QuerydslSupport
+import org.springframework.aot.hint.MemberCategory
 import org.springframework.aot.hint.RuntimeHints
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates
 import kotlin.test.Test
@@ -21,5 +22,29 @@ class QuerydslKtxRuntimeHintsTest {
         val hints = RuntimeHints()
         QuerydslKtxRuntimeHints().registerHints(hints, javaClass.classLoader)
         assertTrue(RuntimeHintsPredicates.reflection().onType(QuerydslRepository::class.java).test(hints))
+    }
+
+    @Test
+    fun `registers INVOKE_DECLARED_METHODS for QuerydslSupport`() {
+        val hints = RuntimeHints()
+        QuerydslKtxRuntimeHints().registerHints(hints, javaClass.classLoader)
+        assertTrue(
+            RuntimeHintsPredicates.reflection()
+                .onType(QuerydslSupport::class.java)
+                .withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS)
+                .test(hints)
+        )
+    }
+
+    @Test
+    fun `registers INVOKE_DECLARED_METHODS for QuerydslRepository`() {
+        val hints = RuntimeHints()
+        QuerydslKtxRuntimeHints().registerHints(hints, javaClass.classLoader)
+        assertTrue(
+            RuntimeHintsPredicates.reflection()
+                .onType(QuerydslRepository::class.java)
+                .withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS)
+                .test(hints)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- `QuerydslKtxRuntimeHints`에 `INVOKE_DECLARED_METHODS` 추가하여 `@PersistenceContext`, `@Autowired`, `@PostConstruct` 등 private setter injection이 GraalVM native image에서 동작하도록 수정
- `QuerydslKtxAutoConfiguration`에 `@ConditionalOnSingleCandidate(EntityManager::class)` 추가하여 multi-datasource 환경에서 안전하게 비활성화
- 위 변경사항에 대한 테스트 추가

## Test plan
- [x] `INVOKE_DECLARED_METHODS` 등록 검증 테스트 (QuerydslSupport, QuerydslRepository)
- [x] 다중 EntityManager 빈 존재 시 auto-configuration 비활성화 테스트
- [x] `./gradlew :querydsl-ktx-spring-boot:test` 전체 통과 확인

Closes #52, Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)