### PR TITLE
chore: .gitignore 보안 패턴 추가 및 CI Spring Boot 3.5.0 매트릭스 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['17', '21']
-        spring-boot: ['3.0.13', '3.2.12', '3.3.8', '3.4.4']
+        spring-boot: ['3.0.13', '3.2.12', '3.3.8', '3.4.4', '3.5.0']
     name: Build (Java ${{ matrix.java }}, Spring Boot ${{ matrix.spring-boot }})
     steps:
       - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,14 @@ out/
 node_modules/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
+
+# Secrets & credentials
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.jks
+secring.gpg
+signing.properties
+local.properties


### PR DESCRIPTION
## Summary
- `.gitignore`에 시크릿/크레덴셜 관련 보안 패턴 추가 (`.env`, `*.pem`, `*.key`, `*.p12`, `*.jks`, `secring.gpg`, `signing.properties`, `local.properties`)
- CI 매트릭스에 Spring Boot 3.5.0 추가

Closes #57, Closes #59

## Test plan
- [ ] `.gitignore` 패턴이 올바르게 동작하는지 확인 (해당 파일들이 git status에 표시되지 않음)
- [ ] CI 워크플로우가 Spring Boot 3.5.0 매트릭스에서 정상 빌드되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)