### PR TITLE
feat: modifying() 트랜잭션 가드 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ mkdocs build                              # Build docs site
 ## Conventions
 
 - Dependencies: `compileOnly` for all external libraries (user provides versions)
+- Spring Data 내부 API 의존: `Querydsl` (`o.s.d.jpa.repository.support`), `SimpleEntityPathResolver` — Spring Boot 3.0~3.4 호환 검증됨. v2.0.0(Spring Boot 4) 마이그레이션 시 검토 필요
 - Pagination: `slice()` (optimistic hasNext) and `exactSlice()` (exact hasNext) return Slice, `page()` returns Page, `fetch()` returns List
-- Bulk DML: wrap in `modifying { }` for flush + clear
+- Bulk DML: wrap in `modifying { }` for flush + clear (requires active transaction; throws `IllegalStateException` otherwise)
 - Naming: verb form (slice, page, fetch), not gerund (slicing, paging, fetching)

--- a/docs/en/guide/bulk-dml.md
+++ b/docs/en/guide/bulk-dml.md
@@ -53,6 +53,7 @@ protected fun <R> modifying(
     clearAutomatically: Boolean = true,
     block: () -> R,
 ): R {
+    check(entityManager.isJoinedToTransaction()) { ... }
     if (flushAutomatically) entityManager.flush()
     return try {
         block()
@@ -64,12 +65,23 @@ protected fun <R> modifying(
 
 The execution order is:
 
-1. **flush**: writes any pending entity changes to the database
-2. **execute**: runs your bulk DML statement
-3. **clear**: evicts all entities from the persistence context (in `finally`)
+1. **transaction check**: throws `IllegalStateException` if no active transaction
+2. **flush**: writes any pending entity changes to the database
+3. **execute**: runs your bulk DML statement
+4. **clear**: evicts all entities from the persistence context (in `finally`)
 
 The `clear` runs in a `finally` block, so the persistence context is cleaned up
 even if the DML statement throws an exception.
+
+::: warning Important notes
+- **Transaction required.** `modifying {}` requires an active transaction.
+  Annotate the calling method or class with `@Transactional`.
+  Without a transaction, an `IllegalStateException` is thrown.
+- **`clear()` detaches all entities.** `entityManager.clear()` evicts every
+  managed entity in the persistence context, not just those affected by the
+  bulk operation. If you hold references to other managed entities in the same
+  transaction, their dirty (unflushed) changes will be lost.
+:::
 
 ---
 

--- a/docs/ko/guide/bulk-dml.md
+++ b/docs/ko/guide/bulk-dml.md
@@ -53,6 +53,7 @@ protected fun <R> modifying(
     clearAutomatically: Boolean = true,
     block: () -> R,
 ): R {
+    check(entityManager.isJoinedToTransaction()) { ... }
     if (flushAutomatically) entityManager.flush()
     return try {
         block()
@@ -64,12 +65,23 @@ protected fun <R> modifying(
 
 실행 순서는 다음과 같습니다:
 
-1. **flush**: 대기 중인 엔티티 변경 사항을 데이터베이스에 기록
-2. **execute**: 벌크 DML 문 실행
-3. **clear**: 영속성 컨텍스트에서 모든 엔티티 제거 (`finally` 블록에서)
+1. **트랜잭션 검사**: 활성 트랜잭션이 없으면 `IllegalStateException` 발생
+2. **flush**: 대기 중인 엔티티 변경 사항을 데이터베이스에 기록
+3. **execute**: 벌크 DML 문 실행
+4. **clear**: 영속성 컨텍스트에서 모든 엔티티 제거 (`finally` 블록에서)
 
 `clear`는 `finally` 블록에서 실행되므로, DML 문에서 예외가 발생하더라도
 영속성 컨텍스트가 정리됩니다.
+
+::: warning 주의사항
+- **트랜잭션 필수.** `modifying {}`은 활성 트랜잭션이 필요합니다.
+  호출하는 메서드 또는 클래스에 `@Transactional`을 선언하세요.
+  트랜잭션이 없으면 `IllegalStateException`이 발생합니다.
+- **`clear()`는 모든 엔티티를 분리합니다.** `entityManager.clear()`는 벌크
+  작업의 대상 엔티티만이 아니라, 영속성 컨텍스트의 모든 관리 엔티티를 분리합니다.
+  같은 트랜잭션에서 다른 관리 엔티티의 참조를 보유하고 있다면, 플러시되지 않은
+  변경 사항이 손실됩니다.
+:::
 
 ---
 

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/QuerydslSupport.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/QuerydslSupport.kt
@@ -448,11 +448,40 @@ abstract class QuerydslSupport<T : Any> {
     // modifying
     // ========================================
 
+    /**
+     * Wraps a bulk DML block with automatic [flush][EntityManager.flush] before
+     * and [clear][EntityManager.clear] after execution.
+     *
+     * An active transaction is **required**. If the calling method is not
+     * annotated with `@Transactional` (or otherwise joined to a transaction),
+     * an [IllegalStateException] is thrown immediately.
+     *
+     * ```kotlin
+     * @Transactional
+     * fun deactivateExpired(cutoffDate: LocalDate): Long =
+     *     modifying {
+     *         update(member)
+     *             .set(member.active, false)
+     *             .where(member.lastLogin lt cutoffDate)
+     *             .execute()
+     *     }
+     * ```
+     *
+     * @param flushAutomatically whether to flush pending changes before the block (default `true`)
+     * @param clearAutomatically whether to clear the persistence context after the block (default `true`)
+     * @param block the bulk DML statements to execute
+     * @return the result of [block]
+     * @throws IllegalStateException if no active transaction is present
+     */
     protected fun <R> modifying(
         flushAutomatically: Boolean = true,
         clearAutomatically: Boolean = true,
         block: () -> R,
     ): R {
+        check(entityManager.isJoinedToTransaction()) {
+            "modifying {} requires an active transaction. " +
+                "Annotate the calling method or class with @Transactional."
+        }
         if (flushAutomatically) entityManager.flush()
         return try {
             block()

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/BulkDmlTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/BulkDmlTest.kt
@@ -12,9 +12,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.transaction.TestTransaction
 import java.time.LocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 @DataJpaTest
@@ -79,5 +81,16 @@ class BulkDmlTest {
     fun `bulk delete - no match returns zero`() {
         val count = orderRepository.deleteByStatus(OrderStatus.PENDING)
         assertEquals(0L, count)
+    }
+
+    // -- transaction guard --
+
+    @Test
+    fun `modifying without transaction throws IllegalStateException`() {
+        TestTransaction.end()
+
+        assertFailsWith<IllegalStateException> {
+            memberRepository.deactivateByStatus(MemberStatus.NORMAL)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `modifying {}` 호출 시 `entityManager.isJoinedToTransaction()` 검사 추가. 활성 트랜잭션 없이 호출하면 `IllegalStateException` 발생
- KDoc에 `@throws IllegalStateException`, `clear()` 범위 경고 추가
- EN/KO 벌크 DML 문서에 트랜잭션 필수 및 `clear()` 주의사항 warning admonition 추가
- AGENTS.md에 Spring Data 내부 API 의존 노트 추가

Closes #53, Closes #60

## Test plan
- [x] `./gradlew :querydsl-ktx:test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)