### PR TITLE
refactor: 빌드 시스템 개선 (compilerOptions 마이그레이션 + Gradle 8.12)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,16 +44,16 @@ subprojects {
         }
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions {
-            freeCompilerArgs = listOf("-Xjsr305=strict")
-            jvmTarget = "17"
-            apiVersion = "1.7"
-            languageVersion = "1.7"
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions {
+            freeCompilerArgs.add("-Xjsr305=strict")
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+            apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_7)
+            languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_7)
         }
     }
 
-    tasks.withType<JavaCompile> {
+    tasks.withType<JavaCompile>().configureEach {
         sourceCompatibility = "17"
         targetCompatibility = "17"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- deprecated `kotlinOptions` DSL을 `compilerOptions` DSL로 마이그레이션 (타입 안전 enum 사용)
- `withType`에 `configureEach` 추가로 Task Configuration Avoidance 적용
- Gradle Wrapper 8.5 → 8.12 업그레이드

## Changes
- `build.gradle.kts`: `kotlinOptions` → `compilerOptions` (JvmTarget.JVM_17, KotlinVersion.KOTLIN_1_7 enum 사용)
- `build.gradle.kts`: `withType<KotlinCompile>` 및 `withType<JavaCompile>`에 `.configureEach` 추가
- `gradle/wrapper/gradle-wrapper.properties`: Gradle 8.5 → 8.12

## Test plan
- [x] `./gradlew build` 전체 빌드 성공 확인 (3개 모듈 모두 통과)
- [x] 기존 단위 테스트 및 통합 테스트 모두 통과

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)