### PR TITLE
fix: inChunked chunkSize 양수 검증 및 edge case 테스트 보강

### DIFF
--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensions.kt
@@ -156,13 +156,17 @@ interface SimpleExpressionExtensions {
      * @param right the collection of values to match against, or null to skip
      * @param chunkSize maximum number of items per IN clause (default 1000)
      * @return chunked IN expression, or null if either side is null
+     * @throws IllegalArgumentException if [chunkSize] is not positive
      * @see inChunked
      */
-    fun <T> SimpleExpression<T>?.inChunked(right: Collection<T>?, chunkSize: Int = 1000): BooleanExpression? = when {
-        this == null || right == null -> null
-        right.size <= chunkSize -> this.`in`(right)
-        else -> right.chunked(chunkSize)
-            .map { chunk -> this.`in`(chunk) }
-            .reduce { acc, expr -> acc.or(expr) }
+    fun <T> SimpleExpression<T>?.inChunked(right: Collection<T>?, chunkSize: Int = 1000): BooleanExpression? {
+        require(chunkSize > 0) { "chunkSize must be positive, but was $chunkSize" }
+        return when {
+            this == null || right == null -> null
+            right.size <= chunkSize -> this.`in`(right)
+            else -> right.chunked(chunkSize)
+                .map { chunk -> this.`in`(chunk) }
+                .reduce { acc, expr -> acc.or(expr) }
+        }
     }
 }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/CaseDslTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/CaseDslTest.kt
@@ -1,5 +1,6 @@
 package com.querydsl.ktx
 
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.StringExpression
 import com.querydsl.ktx.extensions.SimpleExpressionExtensions
@@ -11,6 +12,7 @@ class CaseDslTest : SimpleExpressionExtensions {
 
     private val status: StringExpression = Expressions.stringPath("status")
     private val name: StringExpression = Expressions.stringPath("name")
+    private val active: BooleanExpression = Expressions.booleanPath("active")
 
     // ── Searched CASE ──
 
@@ -80,6 +82,33 @@ class CaseDslTest : SimpleExpressionExtensions {
             `when`("VIP") then 1
             `when`("NORMAL") then 2
             otherwise(0)
+        }
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `searched case - no otherwise called returns null`() {
+        val result = case<String> {
+            `when`(active) then "yes"
+            // no otherwise
+        }
+        assertNull(result)
+    }
+
+    @Test
+    fun `searched case - otherwise with expression`() {
+        val result = case<String> {
+            `when`(active) then "active"
+            otherwise(Expressions.constant("default"))
+        }
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `simple case - otherwise with expression`() {
+        val result = case<String, String>(status) {
+            `when`("VIP") then "premium"
+            otherwise(Expressions.constant("standard"))
         }
         assertNotNull(result)
     }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensionsTest.kt
@@ -4,8 +4,10 @@ import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.SimpleExpression
 import com.querydsl.core.types.dsl.StringExpression
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
 
@@ -248,5 +250,34 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
         val result = status.inChunked(list, chunkSize = 5)
         assertNotNull(result)
         assert(!result.toString().contains("||")) { "Expected single IN without OR, got: $result" }
+    }
+
+    @Test
+    fun `inChunked - chunkSize zero throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            status.inChunked(listOf("A", "B"), chunkSize = 0)
+        }
+    }
+
+    @Test
+    fun `inChunked - negative chunkSize throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            status.inChunked(listOf("A", "B"), chunkSize = -1)
+        }
+    }
+
+    @Test
+    fun `inChunked - single element returns simple IN`() {
+        val result = status.inChunked(listOf("A"))
+        assertNotNull(result)
+        // single element fits within default chunk size, so no OR
+        assertTrue(!result.toString().contains("||"))
+    }
+
+    @Test
+    fun `inChunked - chunkSize 1 creates OR per element`() {
+        val result = status.inChunked(listOf("A", "B", "C"), chunkSize = 1)
+        assertNotNull(result)
+        assertTrue(result.toString().contains(" || "))
     }
 }


### PR DESCRIPTION
## Summary
- `inChunked` 함수에 `require(chunkSize > 0)` 전제조건 추가하여 0 이하 chunkSize 방어
- KDoc에 `@throws IllegalArgumentException` 문서화
- `SimpleExpressionExtensionsTest`: chunkSize 0/음수 예외, 단일 원소 IN, chunkSize=1 OR 분할 테스트 4건 추가
- `CaseDslTest`: otherwise 미호출 시 null 반환, Expression 기반 otherwise 테스트 3건 추가

## Test plan
- [x] `./gradlew :querydsl-ktx:test` 전체 423 테스트 통과 확인
- [x] chunkSize=0, chunkSize=-1 시 `IllegalArgumentException` 발생 확인
- [x] 단일 원소 리스트 → OR 없는 단순 IN 확인
- [x] chunkSize=1 → 원소별 OR 분할 확인
- [x] CaseDsl otherwise 미호출 → null 반환 확인
- [x] CaseDsl Expression otherwise → non-null 반환 확인

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)