### PR TITLE
test: Boolean/Simple/Comparable 테스트 assertion 강화

### DIFF
--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/BooleanExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/BooleanExpressionExtensionsTest.kt
@@ -5,6 +5,7 @@ import com.querydsl.core.types.dsl.Expressions
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
 
@@ -77,6 +78,7 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
     fun `andAnyOf - this non-null, predicates non-null returns AND(OR) expression`() {
         val result = active andAnyOf listOf(visible, deleted)
         assertNotNull(result)
+        assertTrue(result.toString().contains("||"))
     }
 
     @Test
@@ -111,6 +113,7 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
     fun `orAllOf - this non-null, predicates non-null returns OR(AND) expression`() {
         val result = active orAllOf listOf(visible, deleted)
         assertNotNull(result)
+        assertTrue(result.toString().contains("&&"))
     }
 
     @Test
@@ -145,6 +148,7 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
     fun `eq - both non-null returns EQ expression`() {
         val result = active eq true
         assertNotNull(result)
+        assertTrue(result.toString().contains("="))
     }
 
     @Test
@@ -171,6 +175,7 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
     fun `nullif Expression - both non-null returns NULLIF expression`() {
         val result = active nullif visible
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("nullif"))
     }
 
     @Test
@@ -197,6 +202,7 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
     fun `nullif Boolean - both non-null returns NULLIF expression`() {
         val result = active nullif true
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("nullif"))
     }
 
     @Test
@@ -223,6 +229,7 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
     fun `coalesce Expression - both non-null returns COALESCE expression`() {
         val result = active coalesce visible
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("coalesce"))
     }
 
     @Test
@@ -249,6 +256,7 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
     fun `coalesce Boolean - both non-null returns COALESCE expression`() {
         val result = active coalesce true
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("coalesce"))
     }
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/ComparableExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/ComparableExpressionExtensionsTest.kt
@@ -5,6 +5,7 @@ import com.querydsl.core.types.dsl.Expressions
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
 
@@ -18,6 +19,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `gt value - both non-null returns GT expression`() {
         val result = code gt "A"
         assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
     }
 
     @Test
@@ -44,6 +46,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `gt expression - both non-null returns GT expression`() {
         val result = code gt otherCode
         assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
     }
 
     @Test
@@ -70,6 +73,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `goe value - both non-null returns GOE expression`() {
         val result = code goe "A"
         assertNotNull(result)
+        assertTrue(result.toString().contains(">="))
     }
 
     @Test
@@ -96,6 +100,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `goe expression - both non-null returns GOE expression`() {
         val result = code goe otherCode
         assertNotNull(result)
+        assertTrue(result.toString().contains(">="))
     }
 
     @Test
@@ -122,6 +127,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `lt value - both non-null returns LT expression`() {
         val result = code lt "Z"
         assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
     }
 
     @Test
@@ -148,6 +154,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `lt expression - both non-null returns LT expression`() {
         val result = code lt otherCode
         assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
     }
 
     @Test
@@ -174,6 +181,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `loe value - both non-null returns LOE expression`() {
         val result = code loe "Z"
         assertNotNull(result)
+        assertTrue(result.toString().contains("<="))
     }
 
     @Test
@@ -200,6 +208,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `loe expression - both non-null returns LOE expression`() {
         val result = code loe otherCode
         assertNotNull(result)
+        assertTrue(result.toString().contains("<="))
     }
 
     @Test
@@ -259,6 +268,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `between ClosedRange - this non-null returns BETWEEN`() {
         val result = code between ("A".."Z")
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("between"))
     }
 
     @Test
@@ -273,6 +283,8 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `notBetween - this non-null returns NOT BETWEEN`() {
         val result = code notBetween ("A" to "Z")
         assertNotNull(result)
+        val str = result.toString().lowercase()
+        assertTrue(str.contains("not") || str.contains("!"), "Expected NOT BETWEEN expression but got: $result")
     }
 
     @Test
@@ -287,6 +299,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `nullif expression - both non-null returns NULLIF`() {
         val result = code nullif otherCode
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("nullif"))
     }
 
     @Test
@@ -313,6 +326,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `nullif value - both non-null returns NULLIF`() {
         val result = code nullif "DEFAULT"
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("nullif"))
     }
 
     @Test
@@ -339,6 +353,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `coalesce expression - both non-null returns COALESCE`() {
         val result = code coalesce otherCode
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("coalesce"))
     }
 
     @Test
@@ -365,6 +380,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `coalesce value - both non-null returns COALESCE`() {
         val result = code coalesce "DEFAULT"
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("coalesce"))
     }
 
     @Test
@@ -391,6 +407,7 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
     fun `reverse between - value non-null, both bounds non-null returns AND expression`() {
         val result = "M" between (code to otherCode)
         assertNotNull(result)
+        assertTrue(result.toString().contains("&&"))
     }
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensionsTest.kt
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.StringExpression
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
 
@@ -19,6 +20,7 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     fun `eq value - both non-null returns EQ expression`() {
         val result = status eq "ACTIVE"
         assertNotNull(result)
+        assertTrue(result.toString().contains("="))
     }
 
     @Test
@@ -45,6 +47,7 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     fun `eq expression - both non-null returns EQ expression`() {
         val result = status eq defaultStatus
         assertNotNull(result)
+        assertTrue(result.toString().contains("="))
     }
 
     @Test
@@ -71,6 +74,7 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     fun `ne value - both non-null returns NE expression`() {
         val result = status ne "DELETED"
         assertNotNull(result)
+        assertTrue(result.toString().contains("!="))
     }
 
     @Test
@@ -97,6 +101,7 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     fun `ne expression - both non-null returns NE expression`() {
         val result = status ne defaultStatus
         assertNotNull(result)
+        assertTrue(result.toString().contains("!="))
     }
 
     @Test
@@ -123,6 +128,7 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     fun `in - both non-null returns IN expression`() {
         val result = status `in` listOf("ACTIVE", "PENDING")
         assertNotNull(result)
+        assertTrue(result.toString().contains(" in "))
     }
 
     @Test
@@ -155,6 +161,7 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     fun `notIn - both non-null returns NOT IN expression`() {
         val result = status notIn listOf("DELETED", "BLOCKED")
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("not in"))
     }
 
     @Test
@@ -187,6 +194,7 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     fun `inChunked - both non-null with small list returns IN expression`() {
         val result = status inChunked listOf("A", "B", "C")
         assertNotNull(result)
+        assertTrue(result.toString().contains(" in "))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 기존 "both non-null" 테스트에 `toString()` 기반 구조 검증 추가
- Boolean (eq, nullif, coalesce, andAnyOf, orAllOf), Simple (eq, ne, in, notIn, inChunked), Comparable (gt, goe, lt, loe, between, notBetween, nullif, coalesce, reverse between) 대상
- 잘못된 연산자를 반환해도 통과하던 테스트 구조 개선

## Test plan
- [x] `./gradlew :querydsl-ktx:test` 전체 통과

Ref #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)