### PR TITLE
test: Number/String/Temporal/Collection 테스트 assertion 강화

### DIFF
--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/CollectionExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/CollectionExpressionExtensionsTest.kt
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.StringPath
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class CollectionExpressionExtensionsTest : CollectionExpressionExtensions {
 
@@ -26,6 +27,7 @@ class CollectionExpressionExtensionsTest : CollectionExpressionExtensions {
     fun `contains value - both non-null returns expression`() {
         val result = roles contains "ADMIN"
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("in") || result.toString().contains("member"))
     }
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
@@ -5,6 +5,7 @@ import com.querydsl.core.types.dsl.NumberExpression
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NumberExpressionExtensionsTest : NumberExpressionExtensions {
 
@@ -18,6 +19,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `gt value - both non-null returns GT expression`() {
         val result = price gt 10000
         assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
     }
 
     @Test
@@ -44,6 +46,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `gt expression - both non-null returns GT expression`() {
         val result = price gt minPrice
         assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
     }
 
     @Test
@@ -70,6 +73,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `goe value - both non-null returns GOE expression`() {
         val result = price goe 10000
         assertNotNull(result)
+        assertTrue(result.toString().contains(">="))
     }
 
     @Test
@@ -96,6 +100,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `goe expression - both non-null returns GOE expression`() {
         val result = price goe minPrice
         assertNotNull(result)
+        assertTrue(result.toString().contains(">="))
     }
 
     @Test
@@ -122,6 +127,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `lt value - both non-null returns LT expression`() {
         val result = price lt 50000
         assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
     }
 
     @Test
@@ -148,6 +154,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `lt expression - both non-null returns LT expression`() {
         val result = price lt minPrice
         assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
     }
 
     @Test
@@ -174,6 +181,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `loe value - both non-null returns LOE expression`() {
         val result = price loe 50000
         assertNotNull(result)
+        assertTrue(result.toString().contains("<="))
     }
 
     @Test
@@ -200,6 +208,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `loe expression - both non-null returns LOE expression`() {
         val result = price loe minPrice
         assertNotNull(result)
+        assertTrue(result.toString().contains("<="))
     }
 
     @Test
@@ -258,6 +267,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `between ClosedRange - this non-null returns BETWEEN`() {
         val result = price between (10000..50000)
         assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("between"))
     }
 
     @Test
@@ -272,6 +282,8 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `notBetween - this non-null returns NOT BETWEEN`() {
         val result = price notBetween (10000 to 50000)
         assertNotNull(result)
+        val str = result.toString().lowercase()
+        assertTrue(str.contains("not") || str.contains("!"))
     }
 
     @Test
@@ -286,6 +298,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `nullif expression - both non-null returns NULLIF`() {
         val result = price nullif minPrice
         assertNotNull(result)
+        assertTrue(result.toString().contains("nullif("))
     }
 
     @Test
@@ -312,6 +325,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `nullif value - both non-null returns NULLIF`() {
         val result = price nullif 0
         assertNotNull(result)
+        assertTrue(result.toString().contains("nullif("))
     }
 
     @Test
@@ -338,6 +352,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `coalesce expression - both non-null returns COALESCE`() {
         val result = price coalesce minPrice
         assertNotNull(result)
+        assertTrue(result.toString().contains("coalesce("))
     }
 
     @Test
@@ -364,6 +379,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `coalesce value - both non-null returns COALESCE`() {
         val result = price coalesce 0
         assertNotNull(result)
+        assertTrue(result.toString().contains("coalesce("))
     }
 
     @Test
@@ -390,6 +406,7 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
     fun `reverse between - value non-null, both bounds non-null returns AND expression`() {
         val result = 30000 between (price to minPrice)
         assertNotNull(result)
+        assertTrue(result.toString().contains("&&"))
     }
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.StringExpression
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class StringExpressionExtensionsTest : StringExpressionExtensions {
 
@@ -19,6 +20,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `contains string - both non-null returns LIKE expression`() {
         val result = name contains "hong"
         assertNotNull(result)
+        assertTrue(result.toString().contains("contains("))
     }
 
     @Test
@@ -45,6 +47,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `contains expression - both non-null returns LIKE expression`() {
         val result = name contains keyword
         assertNotNull(result)
+        assertTrue(result.toString().contains("contains("))
     }
 
     @Test
@@ -71,6 +74,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `containsIgnoreCase - both non-null returns expression`() {
         val result = name containsIgnoreCase "HONG"
         assertNotNull(result)
+        assertTrue(result.toString().contains("containsIc("))
     }
 
     @Test
@@ -97,6 +101,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `startsWith - both non-null returns expression`() {
         val result = name startsWith "hong"
         assertNotNull(result)
+        assertTrue(result.toString().contains("startsWith("))
     }
 
     @Test
@@ -123,6 +128,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `startsWith expression - both non-null returns expression`() {
         val result = name startsWith keyword
         assertNotNull(result)
+        assertTrue(result.toString().contains("startsWith("))
     }
 
     @Test
@@ -149,6 +155,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `startsWithIgnoreCase - both non-null returns expression`() {
         val result = name startsWithIgnoreCase "HONG"
         assertNotNull(result)
+        assertTrue(result.toString().contains("startsWithIgnoreCase("))
     }
 
     @Test
@@ -175,6 +182,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `endsWith - both non-null returns expression`() {
         val result = name endsWith "@gmail.com"
         assertNotNull(result)
+        assertTrue(result.toString().contains("endsWith("))
     }
 
     @Test
@@ -201,6 +209,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `endsWith expression - both non-null returns expression`() {
         val result = name endsWith keyword
         assertNotNull(result)
+        assertTrue(result.toString().contains("endsWith("))
     }
 
     @Test
@@ -227,6 +236,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `endsWithIgnoreCase - both non-null returns expression`() {
         val result = name endsWithIgnoreCase "@GMAIL.COM"
         assertNotNull(result)
+        assertTrue(result.toString().contains("endsWithIgnoreCase("))
     }
 
     @Test
@@ -253,6 +263,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `equalsIgnoreCase - both non-null returns expression`() {
         val result = name equalsIgnoreCase "admin"
         assertNotNull(result)
+        assertTrue(result.toString().contains("eqIc("))
     }
 
     @Test
@@ -279,6 +290,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `notEqualsIgnoreCase - both non-null returns expression`() {
         val result = name notEqualsIgnoreCase "admin"
         assertNotNull(result)
+        assertTrue(result.toString().contains("!") && result.toString().contains("eqIc("))
     }
 
     @Test
@@ -305,6 +317,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `like - both non-null returns expression`() {
         val result = name like "hong%"
         assertNotNull(result)
+        assertTrue(result.toString().contains("like"))
     }
 
     @Test
@@ -331,6 +344,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `likeIgnoreCase - both non-null returns expression`() {
         val result = name likeIgnoreCase "HONG%"
         assertNotNull(result)
+        assertTrue(result.toString().contains("like"))
     }
 
     @Test
@@ -357,6 +371,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `notLike - both non-null returns expression`() {
         val result = name notLike "test%"
         assertNotNull(result)
+        assertTrue(result.toString().contains("!") && result.toString().contains("like"))
     }
 
     @Test
@@ -383,6 +398,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `matches - both non-null returns expression`() {
         val result = name matches "^[a-z]+$"
         assertNotNull(result)
+        assertTrue(result.toString().contains("matches("))
     }
 
     @Test
@@ -409,6 +425,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `nullif expression - both non-null returns NULLIF`() {
         val result = name nullif keyword
         assertNotNull(result)
+        assertTrue(result.toString().contains("nullif("))
     }
 
     @Test
@@ -435,6 +452,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `nullif value - both non-null returns NULLIF`() {
         val result = name nullif "default"
         assertNotNull(result)
+        assertTrue(result.toString().contains("nullif("))
     }
 
     @Test
@@ -461,6 +479,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `coalesce expression - both non-null returns COALESCE`() {
         val result = name coalesce keyword
         assertNotNull(result)
+        assertTrue(result.toString().contains("coalesce("))
     }
 
     @Test
@@ -487,6 +506,7 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `coalesce value - both non-null returns COALESCE`() {
         val result = name coalesce "unknown"
         assertNotNull(result)
+        assertTrue(result.toString().contains("coalesce("))
     }
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/TemporalExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/TemporalExpressionExtensionsTest.kt
@@ -24,6 +24,7 @@ class TemporalExpressionExtensionsTest : TemporalExpressionExtensions, Comparabl
     fun `after value - both non-null returns AFTER expression`() {
         val result = createdAt after sampleDate
         assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
     }
 
     @Test
@@ -50,6 +51,7 @@ class TemporalExpressionExtensionsTest : TemporalExpressionExtensions, Comparabl
     fun `after expression - both non-null returns AFTER expression`() {
         val result = createdAt after updatedAt
         assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
     }
 
     @Test
@@ -76,6 +78,7 @@ class TemporalExpressionExtensionsTest : TemporalExpressionExtensions, Comparabl
     fun `before value - both non-null returns BEFORE expression`() {
         val result = createdAt before sampleDate
         assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
     }
 
     @Test
@@ -102,6 +105,7 @@ class TemporalExpressionExtensionsTest : TemporalExpressionExtensions, Comparabl
     fun `before expression - both non-null returns BEFORE expression`() {
         val result = createdAt before updatedAt
         assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
     }
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/TemporalExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/TemporalExpressionExtensionsTest.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TemporalExpressionExtensionsTest : TemporalExpressionExtensions, ComparableExpressionExtensions {
 


### PR DESCRIPTION
## Summary
- 기존 "both non-null" 테스트에 `toString()` 기반 구조 검증 추가
- Number (gt, goe, lt, loe, between, notBetween, nullif, coalesce, reverse between)
- String (contains, startsWith, endsWith, equalsIgnoreCase, notEqualsIgnoreCase, like, notLike, matches, nullif, coalesce 등 20개)
- Temporal (after, before)
- Collection (contains)
- 실제 QueryDSL toString 패턴에 맞는 assertion 사용

## Test plan
- [x] `./gradlew :querydsl-ktx:test` 전체 통과

Ref #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)