### PR TITLE
docs: page() 자동 count 제한 조건 명시

### DIFF
--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/QuerydslSupport.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/QuerydslSupport.kt
@@ -223,8 +223,16 @@ abstract class QuerydslSupport<T : Any> {
     /**
      * Performs pagination with an auto-generated count query.
      *
-     * **Warning: Do not use with fetch joins!**
-     * When fetch joins are present, use the overload that accepts a separate count query:
+     * The auto count rewrites the cloned query's SELECT into `COUNT(*)`, which is
+     * only accurate for plain row-returning queries. Use the overload accepting a
+     * custom count query when the main query contains any of the following, as
+     * `COUNT(*)` will silently return a wrong total:
+     *
+     * - Fetch joins — collection joins multiply row counts
+     * - `DISTINCT` — counted rows ignore distinct semantics
+     * - `GROUP BY` / `HAVING` — count reflects groups, not filtered aggregates
+     * - DTO projections that collapse rows
+     *
      * ```kotlin
      * query.page(pageable) {
      *     jpaQueryFactory.select(entity.count()).from(entity).where(condition).fetchOne() ?: 0L
@@ -245,6 +253,10 @@ abstract class QuerydslSupport<T : Any> {
 
     /**
      * Performs pagination with [SortSpec]-based sorting and an auto-generated count query.
+     *
+     * The same `COUNT(*)`-rewrite caveats as [page] apply: fetch joins, `DISTINCT`,
+     * `GROUP BY` / `HAVING`, and row-collapsing projections will produce an incorrect
+     * total. Use the overload accepting a custom count query in those cases.
      *
      * ```kotlin
      * selectFrom(qMember)


### PR DESCRIPTION
## Summary

- `JPAQuery<R>.page(pageable)`와 SortSpec 오버로드 KDoc에 `COUNT(*)` 리라이트가 부정확한 조건(fetch joins, `DISTINCT`, `GROUP BY`/`HAVING`, row-collapsing projection)을 명시
- custom count query 오버로드를 우회 가이드로 제시

## Test plan

- [ ] KDoc 렌더링 검토 (Dokka)
- [x] 기존 테스트 회귀 없음 (코드 변경 없음, 주석만 수정)

Closes #68