### PR TITLE
fix: SortSpec.resolve() 제네릭 캐스팅 바운드 정정

### DIFF
--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/SortSpec.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/SortSpec.kt
@@ -53,16 +53,17 @@ class SortSpec {
      * @param sort the sort specification from the client
      * @return ordered list of [OrderSpecifier]s; empty if no properties matched
      */
-    @Suppress("UNCHECKED_CAST")
     fun resolve(sort: Sort): List<OrderSpecifier<*>> {
         if (sort.isUnsorted) return emptyList()
 
         return sort.mapNotNull { order ->
-            val expression = mappings[order.property]
-                as? Expression<Comparable<Any>>
-                ?: return@mapNotNull null
+            val expression = mappings[order.property] ?: return@mapNotNull null
             val direction = if (order.isAscending) Order.ASC else Order.DESC
-            OrderSpecifier(direction, expression)
+            // OrderSpecifier<T : Comparable<?>> requires a concrete type argument,
+            // which Kotlin cannot express for a star-projected bound. The cast is a
+            // runtime-safe erasure: T is never reflected over by OrderSpecifier.
+            @Suppress("UNCHECKED_CAST")
+            OrderSpecifier(direction, expression as Expression<Comparable<Any>>)
         }
     }
 }


### PR DESCRIPTION
## Summary

- 클래스 레벨 `@Suppress("UNCHECKED_CAST")`를 cast 지점으로 scope 한정
- `Comparable<Any>` 캐스팅이 필요한 이유(Kotlin이 star-projected 바운드를 `OrderSpecifier<T : Comparable<?>>`의 타입 인자로 전달할 수 없음) 주석 추가
- null-filter를 cast보다 먼저 수행하여 가독성 개선

## Test plan

- [x] `./gradlew :querydsl-ktx:test` 434/434 통과
- [x] 기존 SortSpecTest 회귀 없음

Closes #69