### PR TITLE
feat: notBetween 부분 범위 지원

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ All extension functions follow this contract:
 |--------------|-----------|----------|-----------|
 | `and` / `or` | returns arg | returns this | null |
 | `between(Pair)` | null | one-sided comparison (goe/loe) | null |
+| `notBetween(Pair)` | null | one-sided comparison (lt/gt) | null |
 | reverse `between(Pair)` | null | one-sided comparison (loe/goe) | null |
 | `case {}` | n/a | null predicate skips branch | all null → null |
 | All others | null | null | null |

--- a/docs/en/guide/extensions.md
+++ b/docs/en/guide/extensions.md
@@ -145,7 +145,7 @@ Comparison and range operators for `Comparable` types (dates, strings, enums, et
 | `loe` | `ComparableExpression<T>?.loe(T?)` | `col <= ?` |
 | `between` | `ComparableExpression<T>?.between(Pair<T?, T?>)` | `col BETWEEN ? AND ?` |
 | `between` | `ComparableExpression<T>?.between(ClosedRange<T>)` | `col BETWEEN ? AND ?` |
-| `notBetween` | `ComparableExpression<T>?.notBetween(Pair<T, T>)` | `col NOT BETWEEN ? AND ?` |
+| `notBetween` | `ComparableExpression<T>?.notBetween(Pair<T?, T?>)` | `col NOT BETWEEN ? AND ?` |
 | `between` (reverse) | `T?.between(Pair<ComparableExpression<T>?, ComparableExpression<T>?>)` | `lower <= ? AND upper >= ?` |
 | `nullif` | `ComparableExpression<T>?.nullif(T?)` | `NULLIF(col, ?)` |
 | `coalesce` | `ComparableExpression<T>?.coalesce(T?)` | `COALESCE(col, ?)` |
@@ -268,7 +268,7 @@ operators specifically typed for `NumberExpression`.
 | `loe` | `NumberExpression<T>?.loe(T?)` | `col <= ?` |
 | `between` | `NumberExpression<T>?.between(Pair<T?, T?>)` | `col BETWEEN ? AND ?` |
 | `between` | `NumberExpression<T>?.between(ClosedRange<T>)` | `col BETWEEN ? AND ?` |
-| `notBetween` | `NumberExpression<T>?.notBetween(Pair<T, T>)` | `col NOT BETWEEN ? AND ?` |
+| `notBetween` | `NumberExpression<T>?.notBetween(Pair<T?, T?>)` | `col NOT BETWEEN ? AND ?` |
 | `between` (reverse) | `T?.between(Pair<NumberExpression<T>?, NumberExpression<T>?>)` | `lower <= ? AND upper >= ?` |
 | `nullif` | `NumberExpression<T>?.nullif(T?)` | `NULLIF(col, ?)` |
 | `coalesce` | `NumberExpression<T>?.coalesce(T?)` | `COALESCE(col, ?)` |

--- a/docs/ko/guide/extensions.md
+++ b/docs/ko/guide/extensions.md
@@ -145,7 +145,7 @@ Oracle은 단일 IN 절에 1000개 항목 제한이 있습니다.
 | `loe` | `ComparableExpression<T>?.loe(T?)` | `col <= ?` |
 | `between` | `ComparableExpression<T>?.between(Pair<T?, T?>)` | `col BETWEEN ? AND ?` |
 | `between` | `ComparableExpression<T>?.between(ClosedRange<T>)` | `col BETWEEN ? AND ?` |
-| `notBetween` | `ComparableExpression<T>?.notBetween(Pair<T, T>)` | `col NOT BETWEEN ? AND ?` |
+| `notBetween` | `ComparableExpression<T>?.notBetween(Pair<T?, T?>)` | `col NOT BETWEEN ? AND ?` |
 | `between` (역방향) | `T?.between(Pair<ComparableExpression<T>?, ComparableExpression<T>?>)` | `lower <= ? AND upper >= ?` |
 | `nullif` | `ComparableExpression<T>?.nullif(T?)` | `NULLIF(col, ?)` |
 | `coalesce` | `ComparableExpression<T>?.coalesce(T?)` | `COALESCE(col, ?)` |
@@ -282,7 +282,7 @@ QueryDSL의 타입 계층에서 `NumberExpression`은 `ComparableExpression`을 
 | `loe` | `NumberExpression<T>?.loe(T?)` | `col <= ?` |
 | `between` | `NumberExpression<T>?.between(Pair<T?, T?>)` | `col BETWEEN ? AND ?` |
 | `between` | `NumberExpression<T>?.between(ClosedRange<T>)` | `col BETWEEN ? AND ?` |
-| `notBetween` | `NumberExpression<T>?.notBetween(Pair<T, T>)` | `col NOT BETWEEN ? AND ?` |
+| `notBetween` | `NumberExpression<T>?.notBetween(Pair<T?, T?>)` | `col NOT BETWEEN ? AND ?` |
 | `between` (역방향) | `T?.between(Pair<NumberExpression<T>?, NumberExpression<T>?>)` | `lower <= ? AND upper >= ?` |
 | `nullif` | `NumberExpression<T>?.nullif(T?)` | `NULLIF(col, ?)` |
 | `coalesce` | `NumberExpression<T>?.coalesce(T?)` | `COALESCE(col, ?)` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -103,7 +103,7 @@ infix fun <T : Comparable<T>> ComparableExpression<T>?.loe(right: T?): BooleanEx
 infix fun <T : Comparable<T>> ComparableExpression<T>?.loe(right: Expression<T>?): BooleanExpression?
 infix fun <T : Comparable<T>> ComparableExpression<T>?.between(range: Pair<T?, T?>): BooleanExpression?
 infix fun <T : Comparable<T>> ComparableExpression<T>?.between(range: ClosedRange<T>): BooleanExpression?
-infix fun <T : Comparable<T>> ComparableExpression<T>?.notBetween(range: Pair<T, T>): BooleanExpression?
+infix fun <T : Comparable<T>> ComparableExpression<T>?.notBetween(range: Pair<T?, T?>): BooleanExpression?
 infix fun <T : Comparable<T>> ComparableExpression<T>?.nullif(other: Expression<T>?): ComparableExpression<T>?
 infix fun <T : Comparable<T>> ComparableExpression<T>?.nullif(other: T?): ComparableExpression<T>?
 infix fun <T : Comparable<T>> ComparableExpression<T>?.coalesce(expr: Expression<T>?): ComparableExpression<T>?

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/ComparableExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/ComparableExpressionExtensions.kt
@@ -209,18 +209,35 @@ interface ComparableExpressionExtensions {
         this?.between(range.start, range.endInclusive)
 
     /**
-     * Null-safe NOT BETWEEN that skips the condition when this is null.
+     * Null-safe NOT BETWEEN with partial range support.
+     *
+     * Mirrors [between] semantics: both bounds yields NOT BETWEEN,
+     * only lower yields `<`, only upper yields `>`, neither skips.
      *
      * ```sql
      * -- from = '2024-01-01', to = '2024-12-31'
      * created_at NOT BETWEEN '2024-01-01' AND '2024-12-31'
+     *
+     * -- from = '2024-01-01', to = null
+     * created_at < '2024-01-01'
+     *
+     * -- from = null, to = '2024-12-31'
+     * created_at > '2024-12-31'
      * ```
      *
-     * @param range a `from to to` pair with both bounds required
-     * @return `this NOT BETWEEN from AND to`, or null if this is null
+     * @param range a `from to to` pair where either bound can be null
+     * @return NOT BETWEEN clause, one-sided comparison, or null if this is null or both bounds are null
      */
-    infix fun <T : Comparable<T>> ComparableExpression<T>?.notBetween(range: Pair<T, T>): BooleanExpression? =
-        this?.notBetween(range.first, range.second)
+    infix fun <T : Comparable<T>> ComparableExpression<T>?.notBetween(range: Pair<T?, T?>): BooleanExpression? {
+        val (from, to) = range
+        return when {
+            this == null -> null
+            from != null && to != null -> this.notBetween(from, to)
+            from != null -> this.lt(from)
+            to != null -> this.gt(to)
+            else -> null
+        }
+    }
 
     /**
      * Null-safe NULLIF that returns SQL NULL when this equals [other].

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensions.kt
@@ -223,19 +223,36 @@ interface NumberExpressionExtensions {
         this?.between(range.start, range.endInclusive)
 
     /**
-     * Null-safe NOT BETWEEN that skips the condition when this is null.
+     * Null-safe NOT BETWEEN with partial range support.
+     *
+     * Mirrors [between] semantics: both bounds yields NOT BETWEEN,
+     * only lower yields `<`, only upper yields `>`, neither skips.
      *
      * ```sql
      * -- from = 10000, to = 50000
      * price NOT BETWEEN 10000 AND 50000
+     *
+     * -- from = 10000, to = null
+     * price < 10000
+     *
+     * -- from = null, to = 50000
+     * price > 50000
      * ```
      *
-     * @param range a `from to to` pair with both bounds required
-     * @return `this NOT BETWEEN from AND to`, or null if this is null
+     * @param range a `from to to` pair where either bound can be null
+     * @return NOT BETWEEN clause, one-sided comparison, or null if this is null or both bounds are null
      */
-    infix fun <T> NumberExpression<T>?.notBetween(range: Pair<T, T>): BooleanExpression?
-        where T : Number, T : Comparable<*> =
-        this?.notBetween(range.first, range.second)
+    infix fun <T> NumberExpression<T>?.notBetween(range: Pair<T?, T?>): BooleanExpression?
+        where T : Number, T : Comparable<*> {
+        val (from, to) = range
+        return when {
+            this == null -> null
+            from != null && to != null -> this.notBetween(from, to)
+            from != null -> this.lt(from)
+            to != null -> this.gt(to)
+            else -> null
+        }
+    }
 
     /**
      * Null-safe NULLIF that returns SQL NULL when this equals [other].

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/ComparableExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/ComparableExpressionExtensionsTest.kt
@@ -293,6 +293,26 @@ class ComparableExpressionExtensionsTest : ComparableExpressionExtensions {
         assertNull(result)
     }
 
+    @Test
+    fun `notBetween - only from returns less-than`() {
+        val result = code notBetween ("A" to null)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
+    }
+
+    @Test
+    fun `notBetween - only to returns greater-than`() {
+        val result = code notBetween (null to "Z")
+        assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
+    }
+
+    @Test
+    fun `notBetween - both bounds null returns null`() {
+        val result = code notBetween (null to null)
+        assertNull(result)
+    }
+
     // ── nullif(Expression) ──
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
@@ -292,6 +292,26 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
         assertNull(result)
     }
 
+    @Test
+    fun `notBetween - only from returns less-than`() {
+        val result = price notBetween (10000 to null)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("<"))
+    }
+
+    @Test
+    fun `notBetween - only to returns greater-than`() {
+        val result = price notBetween (null to 50000)
+        assertNotNull(result)
+        assertTrue(result.toString().contains(">"))
+    }
+
+    @Test
+    fun `notBetween - both bounds null returns null`() {
+        val result = price notBetween (null to null)
+        assertNull(result)
+    }
+
     // ── nullif(Expression) ──
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
@@ -58,6 +58,9 @@ class MemberRepository : QuerydslRepository<Member>() {
     fun findByAgeBetweenClosedRange(range: ClosedRange<Int>): List<Member> =
         selectFrom(member).where(member.age between range).fetch()
 
+    fun findByAgeNotBetween(minAge: Int? = null, maxAge: Int? = null): List<Member> =
+        selectFrom(member).where(member.age notBetween (minAge to maxAge)).fetch()
+
     private val memberSort = sortSpec {
         "name" by member.name
         "age" by member.age

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
@@ -237,4 +237,33 @@ class DynamicQueryTest {
         val result = memberRepository.findByCondition()
         assertEquals(5, result.size)
     }
+
+    // -- notBetween (partial range) --
+
+    @Test
+    fun `notBetween pair - both bounds excludes range`() {
+        val result = memberRepository.findByAgeNotBetween(minAge = 25, maxAge = 30)
+        assertEquals(2, result.size) // Charlie(35), Diana(20)
+        assertTrue(result.none { it.age in 25..30 })
+    }
+
+    @Test
+    fun `notBetween pair - lower bound only uses less-than`() {
+        val result = memberRepository.findByAgeNotBetween(minAge = 25)
+        assertEquals(1, result.size) // Diana(20)
+        assertTrue(result.all { it.age < 25 })
+    }
+
+    @Test
+    fun `notBetween pair - upper bound only uses greater-than`() {
+        val result = memberRepository.findByAgeNotBetween(maxAge = 30)
+        assertEquals(1, result.size) // Charlie(35)
+        assertTrue(result.all { it.age > 30 })
+    }
+
+    @Test
+    fun `notBetween pair - both null skips filter`() {
+        val result = memberRepository.findByAgeNotBetween(minAge = null, maxAge = null)
+        assertEquals(5, result.size)
+    }
 }


### PR DESCRIPTION
## Summary

- `Comparable`/`NumberExpression`의 `notBetween`을 `Pair<T?, T?>`로 확장
- `between`과 계약 대칭: 한쪽 bound null → `lt`/`gt`로 degrade, 둘 다 null → skip
- 단위 테스트 4-null 조합 추가 (각 3건)
- 통합 테스트 4건 추가 (`DynamicQueryTest` notBetween 섹션)
- `MemberRepository.findByAgeNotBetween` 추가
- `AGENTS.md` 계약표, `llms-full.txt`, `docs/{en,ko}/guide/extensions.md` 시그니처 동기화

`Pair<out A, out B>`의 공변성 덕에 기존 `Pair<T, T>` 호출자는 source-compatible.

## Test plan

- [x] `./gradlew :querydsl-ktx:test` 434/434 통과
- [x] 통합 테스트 both/from-only/to-only/both-null 4 케이스 확인
- [ ] 기존 `Pair<T, T>` 호출이 컴파일되는지 사용자 코드 회귀 검토

Closes #70