### PR TITLE
fix: QuerydslKtxAutoConfiguration 조건을 EntityManagerFactory 기반으로 교체

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 spring-data-commons = { module = "org.springframework.data:spring-data-commons", version.ref = "spring-data" }
 spring-data-jpa = { module = "org.springframework.data:spring-data-jpa", version.ref = "spring-data" }
+spring-orm = { module = "org.springframework:spring-orm", version.ref = "spring-framework" }
 jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version.ref = "jakarta-persistence" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/querydsl-ktx-spring-boot/build.gradle.kts
+++ b/querydsl-ktx-spring-boot/build.gradle.kts
@@ -8,6 +8,7 @@ val jpaClassifier = extra["jpaClassifier"] as String?
 dependencies {
     implementation(projects.querydslKtx)
     compileOnly(libs.spring.boot.autoconfigure)
+    compileOnly(libs.spring.orm)
     compileOnly(libs.querydsl.jpa) {
         if (jpaClassifier != null) artifact { classifier = jpaClassifier }
     }
@@ -23,6 +24,9 @@ dependencies {
         if (jpaClassifier != null) artifact { classifier = jpaClassifier }
     }
     testImplementation(libs.jakarta.persistence.api)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.boot.starter.data.jpa)
+    testImplementation(libs.h2)
     testImplementation(kotlin("test"))
 }
 

--- a/querydsl-ktx-spring-boot/src/main/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfiguration.kt
+++ b/querydsl-ktx-spring-boot/src/main/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfiguration.kt
@@ -1,7 +1,7 @@
 package com.querydsl.ktx.autoconfigure
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import jakarta.persistence.EntityManager
+import jakarta.persistence.EntityManagerFactory
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -9,14 +9,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandi
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ImportRuntimeHints
+import org.springframework.orm.jpa.SharedEntityManagerCreator
 
 @AutoConfiguration(after = [HibernateJpaAutoConfiguration::class])
 @ConditionalOnClass(JPAQueryFactory::class)
-@ConditionalOnSingleCandidate(EntityManager::class)
+@ConditionalOnSingleCandidate(EntityManagerFactory::class)
 @ImportRuntimeHints(QuerydslKtxRuntimeHints::class)
 class QuerydslKtxAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun jpaQueryFactory(entityManager: EntityManager) = JPAQueryFactory(entityManager)
+    fun jpaQueryFactory(entityManagerFactory: EntityManagerFactory): JPAQueryFactory =
+        JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory))
 }

--- a/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationIntegrationTest.kt
+++ b/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationIntegrationTest.kt
@@ -1,0 +1,57 @@
+package com.querydsl.ktx.autoconfigure
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * 실 Spring Boot JPA 환경에서 AutoConfig가 활성화되고 JPAQueryFactory 빈이
+ * 주입 가능한지 검증. ApplicationContextRunner 기반 단위 테스트는 EntityManager
+ * proxy 빈 등록 타이밍 차이를 잡지 못하므로 이 테스트로 회귀 방지.
+ */
+@SpringBootTest(classes = [QuerydslKtxAutoConfigurationIntegrationTest.TestApp::class])
+@Transactional
+class QuerydslKtxAutoConfigurationIntegrationTest {
+
+    @Autowired
+    lateinit var context: ApplicationContext
+
+    @Autowired
+    lateinit var jpaQueryFactory: JPAQueryFactory
+
+    @Test
+    fun `AutoConfig registers JPAQueryFactory in real Spring Boot JPA context`() {
+        assertTrue(
+            context.containsBean("jpaQueryFactory"),
+            "QuerydslKtxAutoConfiguration should register 'jpaQueryFactory' bean",
+        )
+        assertNotNull(jpaQueryFactory)
+    }
+
+    @Test
+    fun `JPAQueryFactory builds query objects from the shared EntityManager proxy`() {
+        val query = jpaQueryFactory.selectOne()
+        assertNotNull(query)
+    }
+
+    @SpringBootApplication
+    open class TestApp
+
+    @Entity
+    open class Book {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        open var id: Long = 0
+        open var title: String = ""
+    }
+}

--- a/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationTest.kt
+++ b/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationTest.kt
@@ -2,12 +2,14 @@ package com.querydsl.ktx.autoconfigure
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.persistence.EntityManager
+import jakarta.persistence.EntityManagerFactory
 import org.mockito.Mockito
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import java.util.function.Supplier
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -18,10 +20,12 @@ class QuerydslKtxAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(QuerydslKtxAutoConfiguration::class.java))
 
+    private fun mockEmf(): EntityManagerFactory = Mockito.mock(EntityManagerFactory::class.java)
+
     @Test
-    fun `registers JPAQueryFactory when EntityManager is available`() {
+    fun `registers JPAQueryFactory when EntityManagerFactory is available`() {
         contextRunner
-            .withBean(EntityManager::class.java, { Mockito.mock(EntityManager::class.java) })
+            .withBean(EntityManagerFactory::class.java, { mockEmf() })
             .run { context ->
                 assertTrue(context.containsBean("jpaQueryFactory"))
                 assertNotNull(context.getBean(JPAQueryFactory::class.java))
@@ -31,6 +35,7 @@ class QuerydslKtxAutoConfigurationTest {
     @Test
     fun `backs off when user defines JPAQueryFactory bean`() {
         contextRunner
+            .withBean(EntityManagerFactory::class.java, { mockEmf() })
             .withUserConfiguration(CustomJpaQueryFactoryConfig::class.java)
             .run { context ->
                 assertTrue(context.containsBean("customJpaQueryFactory"))
@@ -50,12 +55,22 @@ class QuerydslKtxAutoConfigurationTest {
     }
 
     @Test
-    fun `does not register when multiple EntityManager beans exist`() {
+    fun `does not register when multiple EntityManagerFactory beans exist without Primary`() {
         contextRunner
-            .withBean("em1", EntityManager::class.java, { Mockito.mock(EntityManager::class.java) })
-            .withBean("em2", EntityManager::class.java, { Mockito.mock(EntityManager::class.java) })
+            .withBean("emf1", EntityManagerFactory::class.java, { mockEmf() })
+            .withBean("emf2", EntityManagerFactory::class.java, { mockEmf() })
             .run { context ->
                 assertTrue(!context.containsBean("jpaQueryFactory"))
+            }
+    }
+
+    @Test
+    fun `registers JPAQueryFactory using Primary EntityManagerFactory in multi-datasource setup`() {
+        contextRunner
+            .withUserConfiguration(PrimaryEmfConfig::class.java)
+            .run { context ->
+                assertTrue(context.containsBean("jpaQueryFactory"))
+                assertNotNull(context.getBean(JPAQueryFactory::class.java))
             }
     }
 
@@ -66,5 +81,17 @@ class QuerydslKtxAutoConfigurationTest {
             val em: EntityManager = Mockito.mock(EntityManager::class.java)
             return JPAQueryFactory(Supplier { em })
         }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    internal class PrimaryEmfConfig {
+        @Bean
+        @Primary
+        fun primaryEntityManagerFactory(): EntityManagerFactory =
+            Mockito.mock(EntityManagerFactory::class.java)
+
+        @Bean
+        fun secondaryEntityManagerFactory(): EntityManagerFactory =
+            Mockito.mock(EntityManagerFactory::class.java)
     }
 }

--- a/querydsl-ktx-spring-boot/src/test/resources/application.properties
+++ b/querydsl-ktx-spring-boot/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:h2:mem:autoconfigtest;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary

- v1.0.0의 auto-config가 실 Spring Boot JPA 환경에서 활성화되지 않는 치명 버그 수정
- `@ConditionalOnSingleCandidate` 대상을 `EntityManager` → `EntityManagerFactory`로 교체
- `SharedEntityManagerCreator`로 transactional EntityManager proxy 생성 (Spring Boot 표준 패턴)
- compileOnly 의존성에 `spring-orm` 추가
- 실 `@SpringBootTest` 기반 통합 테스트 신설로 회귀 방지
- `@Primary EntityManagerFactory` multi-datasource 시나리오 테스트 추가

## 근거

진단 결과:
```
EntityManager beans: [jpaSharedEM_entityManagerFactory, jpaSharedEM_AWC_entityManagerFactory]
EntityManagerFactory beans: [entityManagerFactory]
JPAQueryFactory beans: []
OnBeanCondition: match=false, msg=@ConditionalOnSingleCandidate (types: jakarta.persistence.EntityManager) did not find any beans
```

Spring Boot의 EntityManager proxy는 `PersistenceAnnotationBeanPostProcessor`가 auto-config 조건 평가 이후에 등록하므로, `@AutoConfiguration(after = HibernateJpaAutoConfiguration)`로도 조건을 만족시키지 못함.

## Test plan

- [x] `./gradlew :querydsl-ktx-spring-boot:test` 11/11 통과
- [x] `./gradlew build` 전체 통과
- [x] 실 `@SpringBootTest`에서 `JPAQueryFactory` 빈 주입 확인
- [x] `ApplicationContextRunner` 테스트의 EMF 기반 mock 전환 후 정상
- [x] `@Primary EMF` + 2개 EMF 환경에서 AutoConfig 활성화 및 Primary 선택 검증

Closes #74