### PR TITLE
docs: multi-datasource와 @Primary EntityManagerFactory 사용 가이드 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ in QueryDSL dynamic queries. Implementing an interface makes its infix functions
 ### Modules
 
 - `querydsl-ktx` — Core: 8 extension interfaces + top-level utilities (Expressions, CaseDsl) + QuerydslSupport/QuerydslRepository base classes
-- `querydsl-ktx-spring-boot` — AutoConfiguration: JPAQueryFactory auto-registration + GraalVM RuntimeHints for native image support
+- `querydsl-ktx-spring-boot` — AutoConfiguration: JPAQueryFactory auto-registration keyed on `EntityManagerFactory` (single or `@Primary`, multi-datasource supported) via `SharedEntityManagerCreator` + GraalVM RuntimeHints for native image support
 - `querydsl-ktx-spring-boot-starter` — Starter: aggregates the above modules
 
 ### Tech Stack

--- a/README.ko.md
+++ b/README.ko.md
@@ -90,6 +90,7 @@ class MemberRepository : QuerydslRepository<Member>() {
 - **Reified 표현식 템플릿** -- `Expressions.numberTemplate(Float::class.java, ...)` 대신 `numberTemplate<Float>(...)`.
 - **Case/When DSL** -- `case<Int> { when(pred) then value; otherwise(default) }` null-safe 분기.
 - **Bulk DML** -- `modifying { }` 자동 flush/clear.
+- **멀티 데이터소스 지원** -- 여러 데이터소스가 있을 때 auto-config가 `@Primary EntityManagerFactory`를 자동 선택합니다. primary가 아닌 팩토리는 `JPAQueryFactory`를 직접 등록하세요.
 - **GraalVM 네이티브 이미지** -- `@ImportRuntimeHints`를 통해 `RuntimeHints`가 자동 등록되어 네이티브 이미지를 바로 지원합니다.
 
 ## 문서

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Extensions are scoped through **interface implementation** -- no global namespac
 - **Reified expression templates** -- `numberTemplate<Float>(...)` instead of `Expressions.numberTemplate(Float::class.java, ...)`.
 - **Case/When DSL** -- `case<Int> { when(pred) then value; otherwise(default) }` with null-safe branches.
 - **Bulk DML** -- `modifying { }` with auto flush/clear.
+- **Multi-datasource ready** -- auto-config selects the `@Primary EntityManagerFactory` when multiple data sources are present. Non-primary factories require manual `JPAQueryFactory` registration.
 - **GraalVM native image** -- `RuntimeHints` auto-registered via `@ImportRuntimeHints` for out-of-the-box native image support.
 
 ## Documentation

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -84,8 +84,20 @@ The starter auto-registers a `JPAQueryFactory` bean with these conditions:
 | Condition | Purpose |
 |-----------|---------|
 | `@ConditionalOnClass(JPAQueryFactory)` | Only activates when QueryDSL is on the classpath |
+| `@ConditionalOnSingleCandidate(EntityManagerFactory)` | Activates when exactly one `EntityManagerFactory` is present, or one is marked `@Primary` |
 | `@ConditionalOnMissingBean` | Respects any custom `JPAQueryFactory` you define |
-| `@AutoConfiguration(after = HibernateJpaAutoConfiguration)` | Ensures `EntityManager` is ready first |
+| `@AutoConfiguration(after = HibernateJpaAutoConfiguration)` | Runs after Spring Boot JPA auto-configuration completes |
+
+Bean creation:
+
+```kotlin
+@Bean
+@ConditionalOnMissingBean
+fun jpaQueryFactory(entityManagerFactory: EntityManagerFactory): JPAQueryFactory =
+    JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory))
+```
+
+`SharedEntityManagerCreator` produces a transactional `EntityManager` proxy managed by Spring. This is the same pattern Spring Data JPA uses internally.
 
 ::: tip Custom JPAQueryFactory
 If you register your own `JPAQueryFactory` bean (e.g., with custom `JPQLTemplates`),
@@ -99,6 +111,51 @@ class QuerydslConfig {
         JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager)
 }
 ```
+:::
+
+## Multi-datasource Setup
+
+With multiple `EntityManagerFactory` beans, the one marked `@Primary` is selected automatically.
+
+```kotlin
+@Configuration
+class DataSourceConfig {
+
+    @Bean
+    @Primary
+    fun primaryEntityManagerFactory(
+        builder: EntityManagerFactoryBuilder,
+        @Qualifier("primaryDataSource") dataSource: DataSource,
+    ): LocalContainerEntityManagerFactoryBean =
+        builder.dataSource(dataSource).packages("com.example.primary").build()
+
+    @Bean
+    fun secondaryEntityManagerFactory(
+        builder: EntityManagerFactoryBuilder,
+        @Qualifier("secondaryDataSource") dataSource: DataSource,
+    ): LocalContainerEntityManagerFactoryBean =
+        builder.dataSource(dataSource).packages("com.example.secondary").build()
+}
+```
+
+With this setup, the auto-registered `JPAQueryFactory` uses the **primary** datasource.
+
+To query the secondary datasource, register a separate `JPAQueryFactory`:
+
+```kotlin
+@Configuration
+class SecondaryQuerydslConfig {
+
+    @Bean
+    fun secondaryJpaQueryFactory(
+        @Qualifier("secondaryEntityManagerFactory") emf: EntityManagerFactory,
+    ): JPAQueryFactory =
+        JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(emf))
+}
+```
+
+::: warning No @Primary Marker
+If multiple `EntityManagerFactory` beans exist without `@Primary`, the auto-configuration stays inactive. You must register `JPAQueryFactory` manually.
 :::
 
 ## Verify the Setup

--- a/docs/ko/getting-started/installation.md
+++ b/docs/ko/getting-started/installation.md
@@ -84,8 +84,20 @@ implementation("io.github.harryjhin:querydsl-ktx:{{ version }}")
 | 조건 | 목적 |
 |-----------|---------|
 | `@ConditionalOnClass(JPAQueryFactory)` | 클래스패스에 QueryDSL이 있을 때만 활성화 |
+| `@ConditionalOnSingleCandidate(EntityManagerFactory)` | 단일 `EntityManagerFactory` 또는 `@Primary`가 지정된 팩토리가 있을 때만 활성화 |
 | `@ConditionalOnMissingBean` | 직접 정의한 `JPAQueryFactory`가 있으면 자동 설정을 적용하지 않음 |
-| `@AutoConfiguration(after = HibernateJpaAutoConfiguration)` | `EntityManager`가 먼저 준비되도록 보장 |
+| `@AutoConfiguration(after = HibernateJpaAutoConfiguration)` | JPA 자동 설정 이후에 적용되도록 보장 |
+
+빈 생성 방식:
+
+```kotlin
+@Bean
+@ConditionalOnMissingBean
+fun jpaQueryFactory(entityManagerFactory: EntityManagerFactory): JPAQueryFactory =
+    JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory))
+```
+
+`SharedEntityManagerCreator`는 Spring이 관리하는 트랜잭션 `EntityManager` 프록시를 생성합니다. Spring Data JPA 내부 구현과 동일한 패턴입니다.
 
 ::: tip 커스텀 JPAQueryFactory
 직접 `JPAQueryFactory` 빈을 등록하면(예: 커스텀 `JPQLTemplates` 사용),
@@ -99,6 +111,51 @@ class QuerydslConfig {
         JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager)
 }
 ```
+:::
+
+## 멀티 데이터소스 설정
+
+여러 `EntityManagerFactory` 빈이 있는 환경에서는 `@Primary`가 지정된 팩토리가 자동으로 선택됩니다.
+
+```kotlin
+@Configuration
+class DataSourceConfig {
+
+    @Bean
+    @Primary
+    fun primaryEntityManagerFactory(
+        builder: EntityManagerFactoryBuilder,
+        @Qualifier("primaryDataSource") dataSource: DataSource,
+    ): LocalContainerEntityManagerFactoryBean =
+        builder.dataSource(dataSource).packages("com.example.primary").build()
+
+    @Bean
+    fun secondaryEntityManagerFactory(
+        builder: EntityManagerFactoryBuilder,
+        @Qualifier("secondaryDataSource") dataSource: DataSource,
+    ): LocalContainerEntityManagerFactoryBean =
+        builder.dataSource(dataSource).packages("com.example.secondary").build()
+}
+```
+
+위 설정에서 자동 등록되는 `JPAQueryFactory`는 **primary** 데이터소스를 사용합니다.
+
+secondary 데이터소스용 `JPAQueryFactory`가 필요하면 직접 등록하세요:
+
+```kotlin
+@Configuration
+class SecondaryQuerydslConfig {
+
+    @Bean
+    fun secondaryJpaQueryFactory(
+        @Qualifier("secondaryEntityManagerFactory") emf: EntityManagerFactory,
+    ): JPAQueryFactory =
+        JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(emf))
+}
+```
+
+::: warning @Primary 미지정 시
+여러 `EntityManagerFactory` 빈이 있는데 `@Primary`가 없으면 자동 설정이 비활성화됩니다. `JPAQueryFactory`를 직접 등록해야 합니다.
 :::
 
 ## 설정 확인

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -452,9 +452,14 @@ modifying {
 
 The starter auto-registers a `JPAQueryFactory` bean:
 - `@ConditionalOnClass(JPAQueryFactory)` -- only when QueryDSL is on classpath
+- `@ConditionalOnSingleCandidate(EntityManagerFactory)` -- activates with one EMF or a `@Primary` one (multi-datasource compatible)
 - `@ConditionalOnMissingBean` -- respects your custom bean
 - Runs after `HibernateJpaAutoConfiguration`
 - `@ImportRuntimeHints(QuerydslKtxRuntimeHints::class)` -- registers reflection hints for GraalVM native image support
+
+The bean is created with `SharedEntityManagerCreator.createSharedEntityManager(emf)`, producing a transactional `EntityManager` proxy (same pattern as Spring Data JPA).
+
+Multi-datasource: the `@Primary EntityManagerFactory` is selected automatically. For non-primary data sources, register a separate `JPAQueryFactory` bean with the matching `EntityManagerFactory` qualifier.
 
 ## Modules
 


### PR DESCRIPTION
## Summary

- v1.1.0에서 AutoConfig가 EntityManagerFactory 기반으로 전환되며 공식 지원된 multi-datasource 시나리오를 문서화
- README Features에 "Multi-datasource ready" 행 추가 (EN/KO)
- docs/{en,ko}/getting-started/installation.md: AutoConfig 조건 테이블 보강 + Multi-datasource Setup 섹션 신설
- llms-full.txt / AGENTS.md 동기화

## Test plan

- [x] VitePress 문법(\`::: tip/warning\`) 준수
- [x] docs/CLAUDE.md 규칙 준수 (em dash 미사용, {{ version }} 유지)

Closes #76