### PR TITLE
chore: querydsl-ktx-spring-boot 테스트 의존성 및 설정 정리

### DIFF
--- a/querydsl-ktx-spring-boot/build.gradle.kts
+++ b/querydsl-ktx-spring-boot/build.gradle.kts
@@ -15,17 +15,11 @@ dependencies {
     compileOnly(libs.jakarta.persistence.api)
     kapt(libs.spring.boot.autoconfigure.processor)
 
-    testImplementation(libs.spring.boot.test.autoconfigure)
-    testImplementation(libs.spring.boot.test)
-    testImplementation(libs.spring.core.test)
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.mockito.core)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.boot.starter.data.jpa)
     testImplementation(libs.querydsl.jpa) {
         if (jpaClassifier != null) artifact { classifier = jpaClassifier }
     }
-    testImplementation(libs.jakarta.persistence.api)
-    testImplementation(libs.spring.boot.starter.test)
-    testImplementation(libs.spring.boot.starter.data.jpa)
     testImplementation(libs.h2)
     testImplementation(kotlin("test"))
 }

--- a/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationIntegrationTest.kt
+++ b/querydsl-ktx-spring-boot/src/test/kotlin/com/querydsl/ktx/autoconfigure/QuerydslKtxAutoConfigurationIntegrationTest.kt
@@ -1,15 +1,10 @@
 package com.querydsl.ktx.autoconfigure
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
-import org.springframework.transaction.annotation.Transactional
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -20,7 +15,6 @@ import kotlin.test.assertTrue
  * proxy 빈 등록 타이밍 차이를 잡지 못하므로 이 테스트로 회귀 방지.
  */
 @SpringBootTest(classes = [QuerydslKtxAutoConfigurationIntegrationTest.TestApp::class])
-@Transactional
 class QuerydslKtxAutoConfigurationIntegrationTest {
 
     @Autowired
@@ -46,12 +40,4 @@ class QuerydslKtxAutoConfigurationIntegrationTest {
 
     @SpringBootApplication
     open class TestApp
-
-    @Entity
-    open class Book {
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        open var id: Long = 0
-        open var title: String = ""
-    }
 }

--- a/querydsl-ktx-spring-boot/src/test/resources/application.properties
+++ b/querydsl-ktx-spring-boot/src/test/resources/application.properties
@@ -1,4 +1,3 @@
 spring.datasource.url=jdbc:h2:mem:autoconfigtest;DB_CLOSE_DELAY=-1
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary

- 중복 `testImplementation` 6개 제거 (`spring-boot-starter-test`, `starter-data-jpa`가 포함)
- `QuerydslKtxAutoConfigurationIntegrationTest`의 `@Transactional` 및 더미 `Book` 엔티티 제거
- `application.properties`의 `hibernate.dialect` 제거 (Spring Boot 3.x 자동 감지)

## Test plan

- [x] `./gradlew :querydsl-ktx-spring-boot:test` 11/11 통과
- [x] `./gradlew build` 전체 통과

Closes #77