### PR TITLE
fix: querydsl-ktx-spring-boot 테스트에 junit-platform-launcher 명시

### DIFF
--- a/querydsl-ktx-spring-boot/build.gradle.kts
+++ b/querydsl-ktx-spring-boot/build.gradle.kts
@@ -22,6 +22,11 @@ dependencies {
     }
     testImplementation(libs.h2)
     testImplementation(kotlin("test"))
+
+    // Spring Boot 3.5+의 junit-bom은 Gradle 기본 번들 launcher보다 신 버전을 요구한다.
+    // 명시적으로 testRuntimeOnly로 BOM 관리 버전을 끌어와야 OutputDirectoryProvider
+    // 호환성 이슈를 피할 수 있다.
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 tasks.test {


### PR DESCRIPTION
## Summary

Spring Boot 3.5.0 매트릭스의 `:querydsl-ktx-spring-boot:test`가 JUnit Platform 버전 불일치로 실패하던 문제 수정.

- `querydsl-ktx-spring-boot/build.gradle.kts`에 `testRuntimeOnly(libs.junit.platform.launcher)` 추가 (`querydsl-ktx` 모듈과 동일 패턴)

## Test plan

- [x] `./gradlew :querydsl-ktx-spring-boot:test -PspringBootVersion=3.5.0` 통과
- [ ] CI 매트릭스 전체 그린 확인

Closes #80