### PR TITLE
feat: BooleanExpression vararg 오버로드 추가

### DIFF
--- a/docs/en/guide/extensions.md
+++ b/docs/en/guide/extensions.md
@@ -74,6 +74,12 @@ active = true AND (role = ? OR department = ?)
 
 :::
 
+::: tip Vararg overload
+`andAnyOf` and `orAllOf` also accept a vararg of `BooleanExpression?`.
+Call with dot notation since Kotlin disallows vararg on infix functions:
+`predicate.andAnyOf(p1, p2, p3)`.
+:::
+
 ---
 
 ## SimpleExpressionExtensions

--- a/docs/ko/guide/extensions.md
+++ b/docs/ko/guide/extensions.md
@@ -74,6 +74,12 @@ active = true AND (role = ? OR department = ?)
 
 :::
 
+::: tip vararg 오버로드
+`andAnyOf`와 `orAllOf`는 vararg `BooleanExpression?`도 받습니다.
+Kotlin은 infix 함수에 vararg를 허용하지 않으므로 점 표기법으로 호출합니다:
+`predicate.andAnyOf(p1, p2, p3)`.
+:::
+
 ---
 
 ## SimpleExpressionExtensions

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -64,7 +64,9 @@ class MyRepo : QuerydslSupport<MyEntity>(), BooleanExpressionExtensions, StringE
 infix fun BooleanExpression?.and(right: BooleanExpression?): BooleanExpression?
 infix fun BooleanExpression?.or(right: BooleanExpression?): BooleanExpression?
 infix fun BooleanExpression?.andAnyOf(predicates: List<BooleanExpression?>): BooleanExpression?
+fun BooleanExpression?.andAnyOf(vararg predicates: BooleanExpression?): BooleanExpression?
 infix fun BooleanExpression?.orAllOf(predicates: List<BooleanExpression?>): BooleanExpression?
+fun BooleanExpression?.orAllOf(vararg predicates: BooleanExpression?): BooleanExpression?
 infix fun BooleanExpression?.eq(right: Boolean?): BooleanExpression?
 infix fun BooleanExpression?.nullif(other: Expression<Boolean>?): BooleanExpression?
 infix fun BooleanExpression?.nullif(other: Boolean?): BooleanExpression?

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/BooleanExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/BooleanExpressionExtensions.kt
@@ -66,6 +66,25 @@ interface BooleanExpressionExtensions {
         this and predicates.reduceOrNull { acc, expr -> acc or expr }
 
     /**
+     * Vararg overload of [andAnyOf] that lets you skip the surrounding `listOf(...)`.
+     *
+     * Cannot be `infix` because Kotlin disallows vararg on infix functions,
+     * so call it with dot notation. Behavior matches the [List] overload.
+     *
+     * ```kotlin
+     * // dot-notation call
+     * predicate.andAnyOf(roleAdmin, roleManager)
+     * // equivalent to:
+     * predicate andAnyOf listOf(roleAdmin, roleManager)
+     * ```
+     *
+     * @param predicates conditions to be OR-combined
+     * @return `this AND (p1 OR p2 OR ...)`, or null if both sides resolve to null
+     */
+    fun BooleanExpression?.andAnyOf(vararg predicates: BooleanExpression?): BooleanExpression? =
+        this andAnyOf predicates.asList()
+
+    /**
      * Combines two conditions with OR, skipping any null side.
      *
      * Use this to build dynamic WHERE clauses where any matching condition suffices.
@@ -105,6 +124,25 @@ interface BooleanExpressionExtensions {
      */
     infix fun BooleanExpression?.orAllOf(predicates: List<BooleanExpression?>): BooleanExpression? =
         this or predicates.reduceOrNull { acc, expr -> acc and expr }
+
+    /**
+     * Vararg overload of [orAllOf] that lets you skip the surrounding `listOf(...)`.
+     *
+     * Cannot be `infix` because Kotlin disallows vararg on infix functions,
+     * so call it with dot notation. Behavior matches the [List] overload.
+     *
+     * ```kotlin
+     * // dot-notation call
+     * predicate.orAllOf(active, ageGoe20)
+     * // equivalent to:
+     * predicate orAllOf listOf(active, ageGoe20)
+     * ```
+     *
+     * @param predicates conditions to be AND-combined
+     * @return `this OR (p1 AND p2 AND ...)`, or null if both sides resolve to null
+     */
+    fun BooleanExpression?.orAllOf(vararg predicates: BooleanExpression?): BooleanExpression? =
+        this orAllOf predicates.asList()
 
     /**
      * Null-safe equality check for boolean expressions.

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/BooleanExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/BooleanExpressionExtensionsTest.kt
@@ -142,6 +142,92 @@ class BooleanExpressionExtensionsTest : BooleanExpressionExtensions {
         assert(result === active)
     }
 
+    // ── andAnyOf vararg ──
+
+    @Test
+    fun `andAnyOf vararg - this non-null, predicates non-null returns AND(OR) expression`() {
+        val result = active.andAnyOf(visible, deleted)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("||"))
+    }
+
+    @Test
+    fun `andAnyOf vararg - this null, predicates non-null returns OR of predicates`() {
+        val result = nullExpr.andAnyOf(visible, deleted)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("||"))
+    }
+
+    @Test
+    fun `andAnyOf vararg - this non-null, predicates all null returns this`() {
+        val result = active.andAnyOf(null, null)
+        assertNotNull(result)
+        assert(result === active)
+    }
+
+    @Test
+    fun `andAnyOf vararg - both null returns null`() {
+        val result = nullExpr.andAnyOf(null, null)
+        assertNull(result)
+    }
+
+    @Test
+    fun `andAnyOf vararg - empty vararg returns this`() {
+        val result = active.andAnyOf()
+        assertNotNull(result)
+        assert(result === active)
+    }
+
+    @Test
+    fun `andAnyOf vararg - single predicate returns AND expression`() {
+        val result = active.andAnyOf(visible)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("&&"))
+    }
+
+    // ── orAllOf vararg ──
+
+    @Test
+    fun `orAllOf vararg - this non-null, predicates non-null returns OR(AND) expression`() {
+        val result = active.orAllOf(visible, deleted)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("&&"))
+    }
+
+    @Test
+    fun `orAllOf vararg - this null, predicates non-null returns AND of predicates`() {
+        val result = nullExpr.orAllOf(visible, deleted)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("&&"))
+    }
+
+    @Test
+    fun `orAllOf vararg - this non-null, predicates all null returns this`() {
+        val result = active.orAllOf(null, null)
+        assertNotNull(result)
+        assert(result === active)
+    }
+
+    @Test
+    fun `orAllOf vararg - both null returns null`() {
+        val result = nullExpr.orAllOf(null, null)
+        assertNull(result)
+    }
+
+    @Test
+    fun `orAllOf vararg - empty vararg returns this`() {
+        val result = active.orAllOf()
+        assertNotNull(result)
+        assert(result === active)
+    }
+
+    @Test
+    fun `orAllOf vararg - single predicate returns OR expression`() {
+        val result = active.orAllOf(visible)
+        assertNotNull(result)
+        assertTrue(result.toString().contains("||"))
+    }
+
     // ── eq ──
 
     @Test

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
@@ -108,6 +108,27 @@ class MemberRepository : QuerydslRepository<Member>() {
             .where(member.id inChunked ids)
             .fetch()
 
+    fun findVipInAnyOf(vararg departmentNames: String?): List<Member> =
+        selectFrom(member)
+            .leftJoin(member.department, department)
+            .where(
+                (member.status eq MemberStatus.VIP).andAnyOf(
+                    *departmentNames.map { department.name eq it }.toTypedArray(),
+                ),
+            )
+            .fetch()
+
+    fun findActiveOrAllOf(minAge: Int?, departmentName: String?): List<Member> =
+        selectFrom(member)
+            .leftJoin(member.department, department)
+            .where(
+                (member.status eq MemberStatus.VIP).orAllOf(
+                    member.age goe minAge,
+                    department.name eq departmentName,
+                ),
+            )
+            .fetch()
+
     // Non-SortSpec pagination — uses Pageable's own Sort
     fun findPageDirect(pageable: Pageable): Page<Member> =
         selectFrom(member).page(pageable)

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
@@ -266,4 +266,40 @@ class DynamicQueryTest {
         val result = memberRepository.findByAgeNotBetween(minAge = null, maxAge = null)
         assertEquals(5, result.size)
     }
+
+    // -- andAnyOf vararg --
+
+    @Test
+    fun `andAnyOf vararg - VIP in any of given departments`() {
+        val result = memberRepository.findVipInAnyOf("Engineering", "Marketing")
+        // Alice (VIP, Engineering), Charlie (VIP, Marketing)
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.status == MemberStatus.VIP })
+    }
+
+    @Test
+    fun `andAnyOf vararg - empty vararg keeps base predicate only`() {
+        val result = memberRepository.findVipInAnyOf()
+        // VIP regardless of department: Alice, Charlie
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.status == MemberStatus.VIP })
+    }
+
+    // -- orAllOf vararg --
+
+    @Test
+    fun `orAllOf vararg - VIP OR (minAge AND department)`() {
+        val result = memberRepository.findActiveOrAllOf(minAge = 30, departmentName = "Marketing")
+        // VIP (Alice, Charlie) OR (age >= 30 AND dept = Marketing -> Charlie)
+        // Union: Alice, Charlie
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `orAllOf vararg - all predicates null returns VIP only`() {
+        val result = memberRepository.findActiveOrAllOf(minAge = null, departmentName = null)
+        // null args -> all predicates null -> orAllOf reduces to base (VIP only)
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.status == MemberStatus.VIP })
+    }
 }


### PR DESCRIPTION
## 요약
- `BooleanExpression`의 `andAnyOf` / `orAllOf`에 vararg 오버로드 추가 (dot 표기법)
- 기존 infix List 변형 유지. vararg는 List 변형으로 위임하여 동작 일치 보장
- 단위 테스트 12개, 통합 테스트 4개, 문서 (EN/KO + llms-full.txt) 갱신

## 설계 결정
Kotlin은 `infix` 함수에 vararg 매개변수를 허용하지 않으므로 vararg 변형은 dot 표기법으로 호출한다. 기존 호출 측 (`expr andAnyOf listOf(...)`)은 그대로 동작한다.

```kotlin
// 기존 (infix, List)
predicate andAnyOf listOf(p1, p2)

// 신규 (dot, vararg)
predicate.andAnyOf(p1, p2, p3)
```

## 테스트 계획
- [x] `./gradlew :querydsl-ktx:test` 통과 (단위 + 통합)
- [ ] CI 매트릭스 (Spring Boot 3.0 / 3.2 / 3.3 / 3.4) 푸시 후 자동 검증

Closes #92