### PR TITLE
feat: StringExpression LIKE 이스케이프 변형 추가

### DIFF
--- a/docs/en/guide/extensions.md
+++ b/docs/en/guide/extensions.md
@@ -366,6 +366,17 @@ LOWER(email) = LOWER(?)
 
 :::
 
+::: tip Escape character for literal % and _
+Use `escapedLike`, `escapedNotLike`, and `escapedLikeIgnoreCase` when the
+pattern contains literal `%` or `_` characters that should not be wildcards.
+A separate name avoids dispatching to QueryDSL's own `like(String, char)`
+member function, which would NPE on a null pattern.
+
+```kotlin
+name.escapedLike("10\\%off", '\\')   // matches "10%off" literally
+```
+:::
+
 ---
 
 ## TemporalExpressionExtensions

--- a/docs/ko/guide/extensions.md
+++ b/docs/ko/guide/extensions.md
@@ -380,6 +380,17 @@ LOWER(email) = LOWER(?)
 
 :::
 
+::: tip 리터럴 % / _ 매칭을 위한 escape 문자
+패턴에 와일드카드가 아닌 리터럴 `%` 혹은 `_`가 들어갈 때는 `escapedLike`,
+`escapedNotLike`, `escapedLikeIgnoreCase`를 사용합니다. 별도 이름을 둔 이유는
+QueryDSL이 제공하는 `like(String, char)` member function과 dispatch가 충돌하면
+null 패턴에서 NPE가 발생하기 때문입니다.
+
+```kotlin
+name.escapedLike("10\\%off", '\\')   // "10%off"를 리터럴로 매칭
+```
+:::
+
 ---
 
 ## TemporalExpressionExtensions

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -137,6 +137,12 @@ infix fun StringExpression?.containsIgnoreCase(right: String?): BooleanExpressio
 infix fun StringExpression?.startsWith(right: String?): BooleanExpression?
 infix fun StringExpression?.startsWith(right: Expression<String>?): BooleanExpression?
 infix fun StringExpression?.startsWithIgnoreCase(right: String?): BooleanExpression?
+fun StringExpression?.escapedLike(pattern: String?, escape: Char): BooleanExpression?
+fun StringExpression?.escapedLike(pattern: Expression<String>?, escape: Char): BooleanExpression?
+fun StringExpression?.escapedLikeIgnoreCase(pattern: String?, escape: Char): BooleanExpression?
+fun StringExpression?.escapedLikeIgnoreCase(pattern: Expression<String>?, escape: Char): BooleanExpression?
+fun StringExpression?.escapedNotLike(pattern: String?, escape: Char): BooleanExpression?
+fun StringExpression?.escapedNotLike(pattern: Expression<String>?, escape: Char): BooleanExpression?
 infix fun StringExpression?.endsWith(right: String?): BooleanExpression?
 infix fun StringExpression?.endsWith(right: Expression<String>?): BooleanExpression?
 infix fun StringExpression?.endsWithIgnoreCase(right: String?): BooleanExpression?

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensions.kt
@@ -244,6 +244,132 @@ interface StringExpressionExtensions {
     }
 
     /**
+     * Null-safe LIKE pattern match with an explicit escape character.
+     *
+     * Use this when the pattern contains literal `%` or `_` characters that
+     * should not be interpreted as wildcards. The [escape] character marks
+     * the next character as a literal.
+     *
+     * Cannot be `infix` because Kotlin disallows multiple parameters on
+     * infix functions, so call with dot notation. Skips the condition when
+     * either side is null.
+     *
+     * ```sql
+     * -- this = entity.code, pattern = '10\%off', escape = '\'
+     * code LIKE '10\%off' ESCAPE '\'
+     * ```
+     *
+     * @param pattern the LIKE pattern, or null to skip
+     * @param escape the escape character for literal `%` and `_`
+     * @return `this LIKE pattern ESCAPE escape`, or null if either side is null
+     */
+    fun StringExpression?.escapedLike(pattern: String?, escape: Char): BooleanExpression? = when {
+        this == null || pattern == null -> null
+        else -> this.like(pattern, escape)
+    }
+
+    /**
+     * Null-safe LIKE against another expression with an explicit escape character.
+     *
+     * Cannot be `infix` because Kotlin disallows multiple parameters on
+     * infix functions, so call with dot notation. Skips the condition when
+     * either side is null.
+     *
+     * ```sql
+     * code LIKE pattern_column ESCAPE '\'
+     * ```
+     *
+     * @param pattern the pattern expression, or null to skip
+     * @param escape the escape character
+     * @return `this LIKE pattern ESCAPE escape`, or null if either side is null
+     */
+    fun StringExpression?.escapedLike(pattern: Expression<String>?, escape: Char): BooleanExpression? = when {
+        this == null || pattern == null -> null
+        else -> this.like(pattern, escape)
+    }
+
+    /**
+     * Null-safe case-insensitive LIKE with an explicit escape character.
+     *
+     * Cannot be `infix` because Kotlin disallows multiple parameters on
+     * infix functions, so call with dot notation. Skips the condition when
+     * either side is null.
+     *
+     * ```sql
+     * LOWER(code) LIKE LOWER('10\%off') ESCAPE '\'
+     * ```
+     *
+     * @param pattern the LIKE pattern, or null to skip
+     * @param escape the escape character
+     * @return `this LIKE pattern ESCAPE escape` (case-insensitive), or null if either side is null
+     */
+    fun StringExpression?.escapedLikeIgnoreCase(pattern: String?, escape: Char): BooleanExpression? = when {
+        this == null || pattern == null -> null
+        else -> this.likeIgnoreCase(pattern, escape)
+    }
+
+    /**
+     * Null-safe case-insensitive LIKE against another expression with an
+     * explicit escape character.
+     *
+     * Cannot be `infix` because Kotlin disallows multiple parameters on
+     * infix functions, so call with dot notation. Skips the condition when
+     * either side is null.
+     *
+     * ```sql
+     * LOWER(code) LIKE LOWER(pattern_column) ESCAPE '\'
+     * ```
+     *
+     * @param pattern the pattern expression, or null to skip
+     * @param escape the escape character
+     * @return `this LIKE pattern ESCAPE escape` (case-insensitive), or null if either side is null
+     */
+    fun StringExpression?.escapedLikeIgnoreCase(pattern: Expression<String>?, escape: Char): BooleanExpression? = when {
+        this == null || pattern == null -> null
+        else -> this.likeIgnoreCase(pattern, escape)
+    }
+
+    /**
+     * Null-safe NOT LIKE with an explicit escape character.
+     *
+     * Cannot be `infix` because Kotlin disallows multiple parameters on
+     * infix functions, so call with dot notation. Skips the condition when
+     * either side is null.
+     *
+     * ```sql
+     * code NOT LIKE '10\%off' ESCAPE '\'
+     * ```
+     *
+     * @param pattern the LIKE pattern to negate, or null to skip
+     * @param escape the escape character
+     * @return `this NOT LIKE pattern ESCAPE escape`, or null if either side is null
+     */
+    fun StringExpression?.escapedNotLike(pattern: String?, escape: Char): BooleanExpression? = when {
+        this == null || pattern == null -> null
+        else -> this.notLike(pattern, escape)
+    }
+
+    /**
+     * Null-safe NOT LIKE against another expression with an explicit escape character.
+     *
+     * Cannot be `infix` because Kotlin disallows multiple parameters on
+     * infix functions, so call with dot notation. Skips the condition when
+     * either side is null.
+     *
+     * ```sql
+     * code NOT LIKE pattern_column ESCAPE '\'
+     * ```
+     *
+     * @param pattern the pattern expression, or null to skip
+     * @param escape the escape character
+     * @return `this NOT LIKE pattern ESCAPE escape`, or null if either side is null
+     */
+    fun StringExpression?.escapedNotLike(pattern: Expression<String>?, escape: Char): BooleanExpression? = when {
+        this == null || pattern == null -> null
+        else -> this.notLike(pattern, escape)
+    }
+
+    /**
      * Null-safe regex match that skips the condition when either side is null.
      *
      * ```sql

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
@@ -526,4 +526,163 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
         val result = nullExpr coalesce (null as String?)
         assertNull(result)
     }
+
+    // ── like(String, Char) escape ──
+
+    @Test
+    fun `like string with escape - both non-null returns LIKE expression`() {
+        val result = name.escapedLike("10\\%off", '\\')
+        assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("like"))
+    }
+
+    @Test
+    fun `like string with escape - this null returns null`() {
+        val result = nullExpr.escapedLike("10\\%off", '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `like string with escape - pattern null returns null`() {
+        val result = name.escapedLike(null as String?, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `like string with escape - both null returns null`() {
+        val result = nullExpr.escapedLike(null as String?, '\\')
+        assertNull(result)
+    }
+
+    // ── like(Expression, Char) escape ──
+
+    @Test
+    fun `like expression with escape - both non-null returns LIKE expression`() {
+        val result = name.escapedLike(keyword, '\\')
+        assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("like"))
+    }
+
+    @Test
+    fun `like expression with escape - this null returns null`() {
+        val result = nullExpr.escapedLike(keyword, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `like expression with escape - pattern null returns null`() {
+        val result = name.escapedLike(null as Expression<String>?, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `like expression with escape - both null returns null`() {
+        val result = nullExpr.escapedLike(null as Expression<String>?, '\\')
+        assertNull(result)
+    }
+
+    // ── likeIgnoreCase(String, Char) escape ──
+
+    @Test
+    fun `likeIgnoreCase string with escape - both non-null returns expression`() {
+        val result = name.escapedLikeIgnoreCase("10\\%OFF", '\\')
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `likeIgnoreCase string with escape - this null returns null`() {
+        val result = nullExpr.escapedLikeIgnoreCase("10\\%OFF", '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `likeIgnoreCase string with escape - pattern null returns null`() {
+        val result = name.escapedLikeIgnoreCase(null as String?, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `likeIgnoreCase string with escape - both null returns null`() {
+        val result = nullExpr.escapedLikeIgnoreCase(null as String?, '\\')
+        assertNull(result)
+    }
+
+    // ── likeIgnoreCase(Expression, Char) escape ──
+
+    @Test
+    fun `likeIgnoreCase expression with escape - both non-null returns expression`() {
+        val result = name.escapedLikeIgnoreCase(keyword, '\\')
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `likeIgnoreCase expression with escape - this null returns null`() {
+        val result = nullExpr.escapedLikeIgnoreCase(keyword, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `likeIgnoreCase expression with escape - pattern null returns null`() {
+        val result = name.escapedLikeIgnoreCase(null as Expression<String>?, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `likeIgnoreCase expression with escape - both null returns null`() {
+        val result = nullExpr.escapedLikeIgnoreCase(null as Expression<String>?, '\\')
+        assertNull(result)
+    }
+
+    // ── notLike(String, Char) escape ──
+
+    @Test
+    fun `notLike string with escape - both non-null returns expression`() {
+        val result = name.escapedNotLike("10\\%off", '\\')
+        assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("like"))
+    }
+
+    @Test
+    fun `notLike string with escape - this null returns null`() {
+        val result = nullExpr.escapedNotLike("10\\%off", '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `notLike string with escape - pattern null returns null`() {
+        val result = name.escapedNotLike(null as String?, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `notLike string with escape - both null returns null`() {
+        val result = nullExpr.escapedNotLike(null as String?, '\\')
+        assertNull(result)
+    }
+
+    // ── notLike(Expression, Char) escape ──
+
+    @Test
+    fun `notLike expression with escape - both non-null returns expression`() {
+        val result = name.escapedNotLike(keyword, '\\')
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `notLike expression with escape - this null returns null`() {
+        val result = nullExpr.escapedNotLike(keyword, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `notLike expression with escape - pattern null returns null`() {
+        val result = name.escapedNotLike(null as Expression<String>?, '\\')
+        assertNull(result)
+    }
+
+    @Test
+    fun `notLike expression with escape - both null returns null`() {
+        val result = nullExpr.escapedNotLike(null as Expression<String>?, '\\')
+        assertNull(result)
+    }
 }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
@@ -43,6 +43,9 @@ class MemberRepository : QuerydslRepository<Member>() {
     fun findByNameLike(pattern: String? = null): List<Member> =
         selectFrom(member).where(member.name like pattern).fetch()
 
+    fun findByNameLikeWithEscape(pattern: String?, escape: Char = '\\'): List<Member> =
+        selectFrom(member).where(member.name.escapedLike(pattern, escape)).fetch()
+
     fun findByNameContainsIgnoreCase(keyword: String? = null): List<Member> =
         selectFrom(member).where(member.name containsIgnoreCase keyword).fetch()
 

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
@@ -177,6 +177,27 @@ class DynamicQueryTest {
         assertEquals(5, result.size)
     }
 
+    // -- like with escape --
+
+    @Test
+    fun `like with escape - matches literal % character`() {
+        em.persist(Member(name = "10% Discount", age = 0, status = MemberStatus.NORMAL))
+        em.flush()
+        em.clear()
+
+        // Without escape, "10%" would be a wildcard prefix match.
+        // With escape, the % is treated literally.
+        val result = memberRepository.findByNameLikeWithEscape("10\\%%", '\\')
+        assertEquals(1, result.size)
+        assertEquals("10% Discount", result[0].name)
+    }
+
+    @Test
+    fun `like with escape - null pattern skips filter`() {
+        val result = memberRepository.findByNameLikeWithEscape(null, '\\')
+        assertEquals(5, result.size)
+    }
+
     // -- between (Pair) --
 
     @Test


### PR DESCRIPTION
## 요약
- 패턴 안의 리터럴 `%`/`_` 매칭을 위한 escape 변형 6개 추가
- 단위 테스트 24개, 통합 테스트 2개, 문서 (EN/KO + llms-full.txt) 갱신

## 추가된 함수
| 함수 | 시그니처 |
|------|----------|
| `escapedLike` | `StringExpression?.escapedLike(pattern: String?, escape: Char)` |
| `escapedLike` | `StringExpression?.escapedLike(pattern: Expression<String>?, escape: Char)` |
| `escapedLikeIgnoreCase` | `StringExpression?.escapedLikeIgnoreCase(pattern: String?, escape: Char)` |
| `escapedLikeIgnoreCase` | `StringExpression?.escapedLikeIgnoreCase(pattern: Expression<String>?, escape: Char)` |
| `escapedNotLike` | `StringExpression?.escapedNotLike(pattern: String?, escape: Char)` |
| `escapedNotLike` | `StringExpression?.escapedNotLike(pattern: Expression<String>?, escape: Char)` |

## 설계 결정
이슈 본문에는 `like(pattern, escape)` 시그니처로 명시되어 있었으나, QueryDSL `StringExpression`이 이미 동일 이름 멤버 함수 `like(String, char escape)`를 제공한다. Kotlin 디스패치 규칙상 멤버 함수가 확장 함수보다 우선되므로, 확장 함수의 null-safety 분기가 호출되지 않고 null 패턴에서 NPE가 발생하는 문제를 통합 테스트로 확인했다 (`ConstantImpl.<init>`에서 NPE).

이를 회피하기 위해 함수 이름을 `escapedLike` / `escapedNotLike` / `escapedLikeIgnoreCase`로 변경했다. 의미적으로도 "escape가 적용된 like"를 명시적으로 표현한다.

## 테스트 계획
- [x] `./gradlew :querydsl-ktx:test` 통과 (단위 + 통합)
- [x] 통합 테스트에서 `%` 리터럴이 와일드카드로 해석되지 않음을 검증
- [ ] CI 매트릭스 (Spring Boot 3.0 / 3.2 / 3.3 / 3.4) 푸시 후 자동 검증

Closes #91