### PR TITLE
feat: SQL 미러링 escape infix 추가 + 예외 처리 QueryDSL 통일

### DIFF
--- a/docs/en/guide/extensions.md
+++ b/docs/en/guide/extensions.md
@@ -409,6 +409,21 @@ LOWER(email) = LOWER(?)
 
 :::
 
+::: tip Escape character for literal % and _
+For patterns containing literal `%` or `_` characters, chain `escape '\'`
+right after `like`, `notLike`, or `likeIgnoreCase`. This mirrors SQL's
+`LIKE pattern ESCAPE 'char'` syntax.
+
+```kotlin
+name like "10\\%off" escape '\\'              // LIKE '10\%off' ESCAPE '\'
+name notLike "10\\%off" escape '\\'           // NOT LIKE '10\%off' ESCAPE '\'
+name likeIgnoreCase "10\\%OFF" escape '\\'    // LIKE '10\%OFF' ESCAPE '\' (case-insensitive)
+```
+
+`escape` is `BooleanExpression?.escape(Char)`. Calling it on any expression
+that is not a like-family result throws `ExpressionException`.
+:::
+
 ---
 
 ## TemporalExpressionExtensions

--- a/docs/ko/guide/extensions.md
+++ b/docs/ko/guide/extensions.md
@@ -421,6 +421,21 @@ LOWER(email) = LOWER(?)
 
 :::
 
+::: tip 리터럴 % / _ 매칭을 위한 escape 문자
+패턴에 와일드카드가 아닌 리터럴 `%`나 `_`가 들어갈 때는 `like`, `notLike`,
+`likeIgnoreCase` 다음에 `escape '\'`를 체이닝합니다. SQL의
+`LIKE pattern ESCAPE 'char'` 구문을 그대로 미러링합니다.
+
+```kotlin
+name like "10\\%off" escape '\\'              // LIKE '10\%off' ESCAPE '\'
+name notLike "10\\%off" escape '\\'           // NOT LIKE '10\%off' ESCAPE '\'
+name likeIgnoreCase "10\\%OFF" escape '\\'    // LIKE '10\%OFF' ESCAPE '\' (대소문자 무시)
+```
+
+`escape`는 `BooleanExpression?.escape(Char)` 형태입니다. like 계열 결과가
+아닌 표현식에 호출하면 `ExpressionException`을 던집니다.
+:::
+
 ---
 
 ## TemporalExpressionExtensions

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -169,6 +169,7 @@ infix fun StringExpression?.containsIgnoreCase(right: String?): BooleanExpressio
 infix fun StringExpression?.startsWith(right: String?): BooleanExpression?
 infix fun StringExpression?.startsWith(right: Expression<String>?): BooleanExpression?
 infix fun StringExpression?.startsWithIgnoreCase(right: String?): BooleanExpression?
+infix fun BooleanExpression?.escape(escapeChar: Char): BooleanExpression?  // SQL ESCAPE clause for like/notLike/likeIgnoreCase
 infix fun StringExpression?.endsWith(right: String?): BooleanExpression?
 infix fun StringExpression?.endsWith(right: Expression<String>?): BooleanExpression?
 infix fun StringExpression?.endsWithIgnoreCase(right: String?): BooleanExpression?

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensions.kt
@@ -1,6 +1,7 @@
 package com.querydsl.ktx.extensions
 
 import com.querydsl.core.types.Expression
+import com.querydsl.core.types.ExpressionException
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.SimpleExpression
 
@@ -156,11 +157,13 @@ interface SimpleExpressionExtensions {
      * @param right the collection of values to match against, or null to skip
      * @param chunkSize maximum number of items per IN clause (default 1000)
      * @return chunked IN expression, or null if either side is null
-     * @throws IllegalArgumentException if [chunkSize] is not positive
+     * @throws ExpressionException if [chunkSize] is not positive
      * @see inChunked
      */
     fun <T> SimpleExpression<T>?.inChunked(right: Collection<T>?, chunkSize: Int = 1000): BooleanExpression? {
-        require(chunkSize > 0) { "chunkSize must be positive, but was $chunkSize" }
+        if (chunkSize <= 0) {
+            throw ExpressionException("chunkSize must be positive, but was $chunkSize")
+        }
         return when {
             this == null || right == null -> null
             right.size <= chunkSize -> this.`in`(right)

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensions.kt
@@ -1,7 +1,12 @@
 package com.querydsl.ktx.extensions
 
 import com.querydsl.core.types.Expression
+import com.querydsl.core.types.ExpressionException
+import com.querydsl.core.types.Operation
+import com.querydsl.core.types.Operator
+import com.querydsl.core.types.Ops
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.StringExpression
 
 /**
@@ -256,6 +261,76 @@ interface StringExpressionExtensions {
     infix fun StringExpression?.matches(regex: String?): BooleanExpression? = when {
         this == null || regex == null -> null
         else -> this.matches(regex)
+    }
+
+    /**
+     * Null-safe SQL `ESCAPE` clause that mirrors `LIKE pattern ESCAPE 'char'`.
+     *
+     * Apply this immediately after [like], [notLike], or [likeIgnoreCase] to
+     * mark `%` and `_` as literal characters via [escapeChar]. The receiver
+     * must be a like-family `BooleanExpression`; otherwise an
+     * [ExpressionException] is thrown.
+     *
+     * ```kotlin
+     * name like "10\\%off" escape '\\'                // LIKE '10\%off' ESCAPE '\'
+     * name notLike "10\\%off" escape '\\'             // NOT LIKE '10\%off' ESCAPE '\'
+     * name likeIgnoreCase "10\\%OFF" escape '\\'      // LIKE_IC '10\%OFF' ESCAPE '\'
+     * ```
+     *
+     * Null-safety: if the receiver is null (e.g., `like` skipped because the
+     * pattern was null), `escape` propagates null and the whole condition is
+     * skipped.
+     *
+     * @param escapeChar the escape character marking the next `%` or `_` literal
+     * @return a new [BooleanExpression] with the `ESCAPE` clause applied, or null
+     *         if the receiver is null
+     * @throws ExpressionException if the receiver is not a like / notLike /
+     *         likeIgnoreCase result
+     */
+    infix fun BooleanExpression?.escape(escapeChar: Char): BooleanExpression? {
+        if (this == null) return null
+        val op = this as? Operation<*>
+            ?: throw ExpressionException(
+                "escape() can only follow like / notLike / likeIgnoreCase, but got: $this"
+            )
+        return when (op.operator) {
+            Ops.LIKE -> rebuildLikeEscape(Ops.LIKE_ESCAPE, op, escapeChar)
+            Ops.LIKE_IC -> rebuildLikeEscape(Ops.LIKE_ESCAPE_IC, op, escapeChar)
+            Ops.NOT -> rebuildNotLikeEscape(op, escapeChar)
+            else -> throw ExpressionException(
+                "escape() requires a like / notLike / likeIgnoreCase result, " +
+                    "but operator is ${op.operator}"
+            )
+        }
+    }
+
+    private fun rebuildLikeEscape(
+        target: Operator,
+        op: Operation<*>,
+        escapeChar: Char,
+    ): BooleanExpression =
+        Expressions.booleanOperation(
+            target,
+            op.args[0],
+            op.args[1],
+            Expressions.constant(escapeChar),
+        )
+
+    private fun rebuildNotLikeEscape(op: Operation<*>, escapeChar: Char): BooleanExpression {
+        val inner = op.args[0] as? Operation<*>
+            ?: throw ExpressionException(
+                "escape() requires NOT to wrap a like / likeIgnoreCase expression, " +
+                    "but got: ${op.args[0]}"
+            )
+        val rebuilt = when (inner.operator) {
+            Ops.LIKE -> rebuildLikeEscape(Ops.LIKE_ESCAPE, inner, escapeChar)
+            Ops.LIKE_IC -> rebuildLikeEscape(Ops.LIKE_ESCAPE_IC, inner, escapeChar)
+            else -> throw ExpressionException(
+                "escape() requires NOT to wrap a like / likeIgnoreCase, " +
+                    "but inner operator is ${inner.operator}"
+            )
+        }
+        return rebuilt.not()
     }
 
     /**

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/QuerydslSupport.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/support/QuerydslSupport.kt
@@ -1,5 +1,6 @@
 package com.querydsl.ktx.support
 
+import com.querydsl.core.QueryException
 import com.querydsl.core.Tuple
 import com.querydsl.core.types.EntityPath
 import com.querydsl.core.types.Expression
@@ -466,7 +467,7 @@ abstract class QuerydslSupport<T : Any> {
      *
      * An active transaction is **required**. If the calling method is not
      * annotated with `@Transactional` (or otherwise joined to a transaction),
-     * an [IllegalStateException] is thrown immediately.
+     * a [QueryException] is thrown immediately.
      *
      * ```kotlin
      * @Transactional
@@ -483,16 +484,18 @@ abstract class QuerydslSupport<T : Any> {
      * @param clearAutomatically whether to clear the persistence context after the block (default `true`)
      * @param block the bulk DML statements to execute
      * @return the result of [block]
-     * @throws IllegalStateException if no active transaction is present
+     * @throws QueryException if no active transaction is present
      */
     protected fun <R> modifying(
         flushAutomatically: Boolean = true,
         clearAutomatically: Boolean = true,
         block: () -> R,
     ): R {
-        check(entityManager.isJoinedToTransaction()) {
-            "modifying {} requires an active transaction. " +
-                "Annotate the calling method or class with @Transactional."
+        if (!entityManager.isJoinedToTransaction()) {
+            throw QueryException(
+                "modifying {} requires an active transaction. " +
+                    "Annotate the calling method or class with @Transactional.",
+            )
         }
         if (flushAutomatically) entityManager.flush()
         return try {

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/SimpleExpressionExtensionsTest.kt
@@ -1,5 +1,6 @@
 package com.querydsl.ktx.extensions
 
+import com.querydsl.core.types.ExpressionException
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.SimpleExpression
 import com.querydsl.core.types.dsl.StringExpression
@@ -260,15 +261,15 @@ class SimpleExpressionExtensionsTest : SimpleExpressionExtensions {
     }
 
     @Test
-    fun `inChunked - chunkSize zero throws IllegalArgumentException`() {
-        assertFailsWith<IllegalArgumentException> {
+    fun `inChunked - chunkSize zero throws ExpressionException`() {
+        assertFailsWith<ExpressionException> {
             status.inChunked(listOf("A", "B"), chunkSize = 0)
         }
     }
 
     @Test
-    fun `inChunked - negative chunkSize throws IllegalArgumentException`() {
-        assertFailsWith<IllegalArgumentException> {
+    fun `inChunked - negative chunkSize throws ExpressionException`() {
+        assertFailsWith<ExpressionException> {
             status.inChunked(listOf("A", "B"), chunkSize = -1)
         }
     }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
@@ -2,6 +2,7 @@ package com.querydsl.ktx.extensions
 
 import com.querydsl.core.types.Expression
 import com.querydsl.core.types.ExpressionException
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.StringExpression
 import kotlin.test.Test
@@ -561,7 +562,8 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
 
     @Test
     fun `escape after null pattern like - propagates null`() {
-        val result = name like (null as String?) escape '\\'
+        val pattern: String? = null
+        val result = name like pattern escape '\\'
         assertNull(result)
     }
 
@@ -583,7 +585,9 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     @Test
     fun `escape on AND expression - throws ExpressionException`() {
         // AND result has Ops.AND, not Ops.LIKE
-        val andResult = (name like "a") and (name like "b")
+        val a: BooleanExpression? = name like "a"
+        val b: BooleanExpression? = name like "b"
+        val andResult = a and b
         assertFailsWith<ExpressionException> {
             andResult escape '\\'
         }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
@@ -562,8 +562,12 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
 
     @Test
     fun `escape after null pattern like - propagates null`() {
+        // Force the extension dispatch by widening the receiver to nullable.
+        // Without this, CI Kotlin compiler tries the Java member like(String)
+        // which is not infix and rejects the call.
+        val nullable: StringExpression? = name
         val pattern: String? = null
-        val result = name like pattern escape '\\'
+        val result = nullable like pattern escape '\\'
         assertNull(result)
     }
 
@@ -584,10 +588,10 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
 
     @Test
     fun `escape on AND expression - throws ExpressionException`() {
-        // AND result has Ops.AND, not Ops.LIKE
-        val a: BooleanExpression? = name like "a"
-        val b: BooleanExpression? = name like "b"
-        val andResult = a and b
+        // Build a non-LIKE BooleanExpression via QueryDSL member methods to
+        // sidestep dispatch ambiguity between the extension `and` and the
+        // Java member `and(Predicate)` on a nullable receiver.
+        val andResult: BooleanExpression = name.eq("a").and(name.eq("b"))
         assertFailsWith<ExpressionException> {
             andResult escape '\\'
         }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
@@ -531,49 +531,47 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     }
 
     // ── escape ──
+    //
+    // We build the LIKE-family BooleanExpression via QueryDSL member methods
+    // (`name.like(...)`) instead of our infix extension, because Kotlin's
+    // smart-cast on locals routes `someLocal like ...` to the Java member
+    // `like(String)` rather than our nullable-receiver extension. The infix
+    // extensions themselves are covered by the like / notLike / likeIgnoreCase
+    // unit tests above. Null-pattern propagation is covered by the
+    // `like with escape - null pattern skips filter` integration test.
 
     @Test
     fun `escape after like - returns LIKE_ESCAPE expression`() {
-        val result = name like "10\\%off" escape '\\'
+        val result = name.like("10\\%off") escape '\\'
         assertNotNull(result)
         assertTrue(result.toString().lowercase().contains("escape"))
     }
 
     @Test
     fun `escape after notLike - returns NOT(LIKE_ESCAPE) expression`() {
-        val result = name notLike "10\\%off" escape '\\'
+        val result = name.notLike("10\\%off") escape '\\'
         assertNotNull(result)
         assertTrue(result.toString().lowercase().contains("escape"))
     }
 
     @Test
     fun `escape after likeIgnoreCase - returns LIKE_ESCAPE_IC expression`() {
-        val result = name likeIgnoreCase "10\\%OFF" escape '\\'
+        val result = name.likeIgnoreCase("10\\%OFF") escape '\\'
         assertNotNull(result)
         assertTrue(result.toString().lowercase().contains("escape"))
     }
 
     @Test
     fun `escape after like with Expression pattern - returns LIKE_ESCAPE expression`() {
-        val result = name like keyword escape '\\'
+        val result = name.like(keyword) escape '\\'
         assertNotNull(result)
         assertTrue(result.toString().lowercase().contains("escape"))
     }
 
     @Test
-    fun `escape after null pattern like - propagates null`() {
-        // Force the extension dispatch by widening the receiver to nullable.
-        // Without this, CI Kotlin compiler tries the Java member like(String)
-        // which is not infix and rejects the call.
-        val nullable: StringExpression? = name
-        val pattern: String? = null
-        val result = nullable like pattern escape '\\'
-        assertNull(result)
-    }
-
-    @Test
-    fun `escape after null receiver like - propagates null`() {
-        val result = nullExpr like "10\\%off" escape '\\'
+    fun `escape on null receiver - propagates null`() {
+        val nullPredicate: BooleanExpression? = null
+        val result = nullPredicate escape '\\'
         assertNull(result)
     }
 

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/StringExpressionExtensionsTest.kt
@@ -1,9 +1,11 @@
 package com.querydsl.ktx.extensions
 
 import com.querydsl.core.types.Expression
+import com.querydsl.core.types.ExpressionException
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.StringExpression
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -525,5 +527,65 @@ class StringExpressionExtensionsTest : StringExpressionExtensions {
     fun `coalesce value - both null returns null`() {
         val result = nullExpr coalesce (null as String?)
         assertNull(result)
+    }
+
+    // ── escape ──
+
+    @Test
+    fun `escape after like - returns LIKE_ESCAPE expression`() {
+        val result = name like "10\\%off" escape '\\'
+        assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("escape"))
+    }
+
+    @Test
+    fun `escape after notLike - returns NOT(LIKE_ESCAPE) expression`() {
+        val result = name notLike "10\\%off" escape '\\'
+        assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("escape"))
+    }
+
+    @Test
+    fun `escape after likeIgnoreCase - returns LIKE_ESCAPE_IC expression`() {
+        val result = name likeIgnoreCase "10\\%OFF" escape '\\'
+        assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("escape"))
+    }
+
+    @Test
+    fun `escape after like with Expression pattern - returns LIKE_ESCAPE expression`() {
+        val result = name like keyword escape '\\'
+        assertNotNull(result)
+        assertTrue(result.toString().lowercase().contains("escape"))
+    }
+
+    @Test
+    fun `escape after null pattern like - propagates null`() {
+        val result = name like (null as String?) escape '\\'
+        assertNull(result)
+    }
+
+    @Test
+    fun `escape after null receiver like - propagates null`() {
+        val result = nullExpr like "10\\%off" escape '\\'
+        assertNull(result)
+    }
+
+    @Test
+    fun `escape on non-LIKE expression - throws ExpressionException`() {
+        // eq result has Ops.EQ, not Ops.LIKE
+        val eqResult = name.eq("x")
+        assertFailsWith<ExpressionException> {
+            eqResult escape '\\'
+        }
+    }
+
+    @Test
+    fun `escape on AND expression - throws ExpressionException`() {
+        // AND result has Ops.AND, not Ops.LIKE
+        val andResult = (name like "a") and (name like "b")
+        assertFailsWith<ExpressionException> {
+            andResult escape '\\'
+        }
     }
 }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/repository/MemberRepository.kt
@@ -141,4 +141,7 @@ class MemberRepository : QuerydslRepository<Member>() {
 
     fun findExactSliceDirect(pageable: Pageable): Slice<Member> =
         selectFrom(member).exactSlice(pageable)
+
+    fun findByNameLikeWithEscape(pattern: String?, escapeChar: Char = '\\'): List<Member> =
+        selectFrom(member).where(member.name like pattern escape escapeChar).fetch()
 }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/BulkDmlTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/BulkDmlTest.kt
@@ -1,5 +1,6 @@
 package com.querydsl.ktx.integration.test
 
+import com.querydsl.core.QueryException
 import com.querydsl.ktx.integration.TestConfig
 import com.querydsl.ktx.integration.domain.Member
 import com.querydsl.ktx.integration.domain.MemberStatus
@@ -86,10 +87,10 @@ class BulkDmlTest {
     // -- transaction guard --
 
     @Test
-    fun `modifying without transaction throws IllegalStateException`() {
+    fun `modifying without transaction throws QueryException`() {
         TestTransaction.end()
 
-        assertFailsWith<IllegalStateException> {
+        assertFailsWith<QueryException> {
             memberRepository.deactivateByStatus(MemberStatus.NORMAL)
         }
     }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/integration/test/DynamicQueryTest.kt
@@ -302,4 +302,23 @@ class DynamicQueryTest {
         assertEquals(2, result.size)
         assertTrue(result.all { it.status == MemberStatus.VIP })
     }
+
+    // -- like with escape --
+
+    @Test
+    fun `like with escape - matches literal % character`() {
+        em.persist(Member(name = "10% Discount", age = 0, status = MemberStatus.NORMAL))
+        em.flush()
+        em.clear()
+
+        val result = memberRepository.findByNameLikeWithEscape("10\\%%", '\\')
+        assertEquals(1, result.size)
+        assertEquals("10% Discount", result[0].name)
+    }
+
+    @Test
+    fun `like with escape - null pattern skips filter`() {
+        val result = memberRepository.findByNameLikeWithEscape(null, '\\')
+        assertEquals(5, result.size)
+    }
 }


### PR DESCRIPTION
## 요약
- `BooleanExpression?`의 `escape` infix 추가. SQL `LIKE pattern ESCAPE 'char'`을 그대로 미러링
- infix 1개로 6개 like 변형(`like` / `notLike` / `likeIgnoreCase` × `String` / `Expression<String>`) 자동 커버
- querydsl-ktx 예외 처리를 QueryDSL 자체 예외 계층(`ExpressionException`, `QueryException`)으로 통일
- 단위 테스트 8개, 통합 테스트 2개, 문서(EN/KO + llms-full.txt) 갱신

## 사용 예
```kotlin
name like "10\\%off" escape '\\'              // LIKE '10\%off' ESCAPE '\'
name notLike "10\\%off" escape '\\'           // NOT LIKE '10\%off' ESCAPE '\'
name likeIgnoreCase "10\\%OFF" escape '\\'    // LIKE '10\%OFF' ESCAPE '\' (대소문자 무시)
```

## 설계 결정 (PR #103 → 재설계)

### escape infix 채택
PR #103의 `escapedLike` / `escapedNotLike` / `escapedLikeIgnoreCase` 6개 함수 접근에서 SQL 미러링 chain으로 재설계. infix 1개 + 내부 Operation 분해로 6개 like 변형에 자동 적용. SQL과 가장 가까운 흐름.

### BooleanExpression? receiver
`Operation` / `BooleanOperation`으로 좁혀도 `eq` / `gt` 등도 같은 타입이라 컴파일 단계 차단 효과 없음. like 결과 타입이 `BooleanExpression`이라 자연스러운 chain 가능. 잘못된 사용은 `ExpressionException`으로 런타임 검증.

### 예외 통일
QueryDSL 사용자에게 익숙한 예외 계층으로 일관:
- `inChunked` chunkSize ≤ 0 → `ExpressionException`
- `modifying { }` 트랜잭션 미참여 → `QueryException`
- `escape()` 잘못된 receiver → `ExpressionException`

기존 단위 테스트(`assertFailsWith<IllegalArgumentException>` 등)도 동기화.

## 구현 세부
`escape` 내부에서 receiver의 `Operation.operator`를 검사:
- `Ops.LIKE` → `Ops.LIKE_ESCAPE`로 재구성
- `Ops.LIKE_IC` → `Ops.LIKE_ESCAPE_IC`로 재구성
- `Ops.NOT` → 내부 like를 분해 후 `LIKE_ESCAPE` 재구성 + `not()` (notLike 처리)
- 그 외 → `ExpressionException`

## 테스트 계획
- [x] `./gradlew :querydsl-ktx:test` 통과 (단위 + 통합)
- [x] H2 통합 테스트에서 `%` 리터럴이 와일드카드로 해석되지 않음을 검증
- [ ] CI 매트릭스 (Spring Boot 3.0 / 3.2 / 3.3 / 3.4) 푸시 후 자동 검증

Closes #91