### PR TITLE
feat: NumberExpression 산술 연산 null-safe 래핑

### DIFF
--- a/docs/en/guide/extensions.md
+++ b/docs/en/guide/extensions.md
@@ -251,6 +251,18 @@ The reverse between is also null-safe: if the value is null, the entire expressi
 
 Same API as `ComparableExpressionExtensions`, but for `NumberExpression`.
 
+::: tip Arithmetic operators
+`add`, `subtract`, `multiply`, `divide`, `mod` are also available with the same
+null-safety contract: either side null returns null (the whole arithmetic
+expression is skipped). Each has a value overload and an `Expression<T>` overload.
+
+```kotlin
+entity.price add 1000             // price + 1000
+entity.price multiply taxRate     // price * tax_rate (column ref)
+entity.total divide quantity      // total / quantity
+```
+:::
+
 ### Why a separate interface?
 
 In QueryDSL's type hierarchy, `NumberExpression` does **not** extend `ComparableExpression`.

--- a/docs/ko/guide/extensions.md
+++ b/docs/ko/guide/extensions.md
@@ -265,6 +265,18 @@ now between (event.startAt to event.endAt)
 
 `ComparableExpressionExtensions`와 동일한 API이지만 `NumberExpression`용입니다.
 
+::: tip 산술 연산자
+`add`, `subtract`, `multiply`, `divide`, `mod`도 동일한 null-safety 계약으로
+사용할 수 있습니다. 어느 한쪽이 null이면 null을 반환하여 산술 표현식 자체가
+건너뜁니다. 각 연산자는 값 오버로드와 `Expression<T>` 오버로드를 모두 제공합니다.
+
+```kotlin
+entity.price add 1000             // price + 1000
+entity.price multiply taxRate     // price * tax_rate (다른 컬럼)
+entity.total divide quantity      // total / quantity
+```
+:::
+
 ### 별도 인터페이스인 이유
 
 QueryDSL의 타입 계층에서 `NumberExpression`은 `ComparableExpression`을 **확장하지 않습니다**.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -118,7 +118,21 @@ Reverse `between`: value on the left, expression pair on the right — `now betw
 
 ### NumberExpressionExtensions
 
-Same API as ComparableExpressionExtensions but for `NumberExpression<T>` (which does not extend `ComparableExpression` in QueryDSL's type hierarchy). Includes `gt`, `goe`, `lt`, `loe`, `between(Pair)`, `between(ClosedRange)`, `notBetween`, `nullif`, `coalesce`, reverse `between`, and `rangeTo`.
+Same API as ComparableExpressionExtensions but for `NumberExpression<T>` (which does not extend `ComparableExpression` in QueryDSL's type hierarchy). Includes `gt`, `goe`, `lt`, `loe`, `between(Pair)`, `between(ClosedRange)`, `notBetween`, `nullif`, `coalesce`, reverse `between`, and `rangeTo`. Also provides null-safe arithmetic operators `add`, `subtract`, `multiply`, `divide`, `mod` (each with value and `Expression<T>` overloads).
+
+```kotlin
+infix fun <T> NumberExpression<T>?.add(right: T?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.add(right: Expression<T>?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.subtract(right: T?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.subtract(right: Expression<T>?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.multiply(right: T?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.multiply(right: Expression<T>?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.divide(right: T?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.divide(right: Expression<T>?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.mod(right: T?): NumberExpression<T>?
+infix fun <T> NumberExpression<T>?.mod(right: Expression<T>?): NumberExpression<T>?
+    where T : Number, T : Comparable<*>
+```
 
 ```kotlin
 // Reverse between (value on the left, expression bounds on the right)

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensions.kt
@@ -1,7 +1,9 @@
 package com.querydsl.ktx.extensions
 
 import com.querydsl.core.types.Expression
+import com.querydsl.core.types.Ops
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.NumberExpression
 
 /**
@@ -252,6 +254,171 @@ interface NumberExpressionExtensions {
             to != null -> this.gt(to)
             else -> null
         }
+    }
+
+    /**
+     * Null-safe addition that skips the operation when either side is null.
+     *
+     * ```sql
+     * -- this = entity.price, right = 1000
+     * price + 1000
+     * ```
+     *
+     * @param right the value to add, or null to skip
+     * @return `this + right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.add(right: T?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.ADD, this, Expressions.constant(right))
+    }
+
+    /**
+     * Null-safe addition against another expression.
+     *
+     * ```sql
+     * price + tax
+     * ```
+     *
+     * @param right the expression to add, or null to skip
+     * @return `this + right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.add(right: Expression<T>?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.ADD, this, right)
+    }
+
+    /**
+     * Null-safe subtraction that skips the operation when either side is null.
+     *
+     * ```sql
+     * -- this = entity.price, right = discount
+     * price - discount
+     * ```
+     *
+     * @param right the value to subtract, or null to skip
+     * @return `this - right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.subtract(right: T?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.SUB, this, Expressions.constant(right))
+    }
+
+    /**
+     * Null-safe subtraction against another expression.
+     *
+     * ```sql
+     * price - discount
+     * ```
+     *
+     * @param right the expression to subtract, or null to skip
+     * @return `this - right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.subtract(right: Expression<T>?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.SUB, this, right)
+    }
+
+    /**
+     * Null-safe multiplication that skips the operation when either side is null.
+     *
+     * ```sql
+     * -- this = entity.price, right = taxRate
+     * price * 1.1
+     * ```
+     *
+     * @param right the value to multiply by, or null to skip
+     * @return `this * right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.multiply(right: T?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.MULT, this, Expressions.constant(right))
+    }
+
+    /**
+     * Null-safe multiplication against another expression.
+     *
+     * ```sql
+     * price * tax_rate
+     * ```
+     *
+     * @param right the expression to multiply by, or null to skip
+     * @return `this * right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.multiply(right: Expression<T>?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.MULT, this, right)
+    }
+
+    /**
+     * Null-safe division that skips the operation when either side is null.
+     *
+     * ```sql
+     * -- this = entity.total, right = quantity
+     * total / quantity
+     * ```
+     *
+     * @param right the value to divide by, or null to skip
+     * @return `this / right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.divide(right: T?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.DIV, this, Expressions.constant(right))
+    }
+
+    /**
+     * Null-safe division against another expression.
+     *
+     * ```sql
+     * total / quantity
+     * ```
+     *
+     * @param right the expression to divide by, or null to skip
+     * @return `this / right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.divide(right: Expression<T>?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.DIV, this, right)
+    }
+
+    /**
+     * Null-safe modulo that skips the operation when either side is null.
+     *
+     * ```sql
+     * -- this = entity.id, right = 10
+     * id % 10
+     * ```
+     *
+     * @param right the divisor, or null to skip
+     * @return `this % right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.mod(right: T?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.MOD, this, Expressions.constant(right))
+    }
+
+    /**
+     * Null-safe modulo against another expression.
+     *
+     * ```sql
+     * id % shard_count
+     * ```
+     *
+     * @param right the divisor expression, or null to skip
+     * @return `this % right`, or null if either side is null
+     */
+    infix fun <T> NumberExpression<T>?.mod(right: Expression<T>?): NumberExpression<T>?
+        where T : Number, T : Comparable<*> = when {
+        this == null || right == null -> null
+        else -> Expressions.numberOperation(this.type, Ops.MOD, this, right)
     }
 
     /**

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
@@ -460,4 +460,254 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
         val result = 30000 between (price..minPrice)
         assertNotNull(result)
     }
+
+    // ── add ──
+
+    @Test
+    fun `add value - both non-null returns ADD expression`() {
+        val result = price add 1000
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `add value - this null returns null`() {
+        val result = nullExpr add 1000
+        assertNull(result)
+    }
+
+    @Test
+    fun `add value - right null returns null`() {
+        val result = price add (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `add value - both null returns null`() {
+        val result = nullExpr add (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `add expression - both non-null returns ADD expression`() {
+        val result = price add minPrice
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `add expression - this null returns null`() {
+        val result = nullExpr add minPrice
+        assertNull(result)
+    }
+
+    @Test
+    fun `add expression - right null returns null`() {
+        val result = price add (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `add expression - both null returns null`() {
+        val result = nullExpr add (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    // ── subtract ──
+
+    @Test
+    fun `subtract value - both non-null returns SUB expression`() {
+        val result = price subtract 100
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `subtract value - this null returns null`() {
+        val result = nullExpr subtract 100
+        assertNull(result)
+    }
+
+    @Test
+    fun `subtract value - right null returns null`() {
+        val result = price subtract (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `subtract value - both null returns null`() {
+        val result = nullExpr subtract (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `subtract expression - both non-null returns SUB expression`() {
+        val result = price subtract minPrice
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `subtract expression - this null returns null`() {
+        val result = nullExpr subtract minPrice
+        assertNull(result)
+    }
+
+    @Test
+    fun `subtract expression - right null returns null`() {
+        val result = price subtract (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `subtract expression - both null returns null`() {
+        val result = nullExpr subtract (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    // ── multiply ──
+
+    @Test
+    fun `multiply value - both non-null returns MUL expression`() {
+        val result = price multiply 2
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `multiply value - this null returns null`() {
+        val result = nullExpr multiply 2
+        assertNull(result)
+    }
+
+    @Test
+    fun `multiply value - right null returns null`() {
+        val result = price multiply (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `multiply value - both null returns null`() {
+        val result = nullExpr multiply (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `multiply expression - both non-null returns MUL expression`() {
+        val result = price multiply minPrice
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `multiply expression - this null returns null`() {
+        val result = nullExpr multiply minPrice
+        assertNull(result)
+    }
+
+    @Test
+    fun `multiply expression - right null returns null`() {
+        val result = price multiply (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `multiply expression - both null returns null`() {
+        val result = nullExpr multiply (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    // ── divide ──
+
+    @Test
+    fun `divide value - both non-null returns DIV expression`() {
+        val result = price divide 2
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `divide value - this null returns null`() {
+        val result = nullExpr divide 2
+        assertNull(result)
+    }
+
+    @Test
+    fun `divide value - right null returns null`() {
+        val result = price divide (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `divide value - both null returns null`() {
+        val result = nullExpr divide (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `divide expression - both non-null returns DIV expression`() {
+        val result = price divide minPrice
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `divide expression - this null returns null`() {
+        val result = nullExpr divide minPrice
+        assertNull(result)
+    }
+
+    @Test
+    fun `divide expression - right null returns null`() {
+        val result = price divide (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `divide expression - both null returns null`() {
+        val result = nullExpr divide (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    // ── mod ──
+
+    @Test
+    fun `mod value - both non-null returns MOD expression`() {
+        val result = price mod 10
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `mod value - this null returns null`() {
+        val result = nullExpr mod 10
+        assertNull(result)
+    }
+
+    @Test
+    fun `mod value - right null returns null`() {
+        val result = price mod (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `mod value - both null returns null`() {
+        val result = nullExpr mod (null as Int?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `mod expression - both non-null returns MOD expression`() {
+        val result = price mod minPrice
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `mod expression - this null returns null`() {
+        val result = nullExpr mod minPrice
+        assertNull(result)
+    }
+
+    @Test
+    fun `mod expression - right null returns null`() {
+        val result = price mod (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
+
+    @Test
+    fun `mod expression - both null returns null`() {
+        val result = nullExpr mod (null as NumberExpression<Int>?)
+        assertNull(result)
+    }
 }


### PR DESCRIPTION
## 요약
- `NumberExpression<T>?`에 산술 연산 5종 × 2 시그니처 = 10 함수 추가
- `add` / `subtract` / `multiply` / `divide` / `mod` × {value, Expression}
- 단위 테스트 40개 (각 함수 4-null 매트릭스)
- 문서(EN/KO + llms-full.txt) 갱신

## 사용 예
```kotlin
entity.price add 1000             // price + 1000
entity.price multiply taxRate     // price * tax_rate (다른 컬럼)
entity.total divide quantity      // total / quantity
```

## 구현 결정 (StackOverflow 회피)
초기 구현은 기존 `gt` / `goe` 패턴을 따라 `else -> this.add(right)`로 작성했으나, 산술 연산에서 Kotlin이 interface default ext function을 member function보다 우선 dispatch하여 **무한 재귀 (StackOverflow)** 발생. (`gt` 등은 같은 패턴인데도 발생 안 함 — 이유 미확인, Kotlin overload resolution의 미묘한 차이)

해결: `Expressions.numberOperation(this.type, Ops.ADD/SUB/MULT/DIV/MOD, this, ...)`로 QueryDSL Operation을 직접 생성. 자기 호출 회피.

## 통합 테스트
v1.2.0 사이클 후속 PR에서 추가 예정 (현재 단위 테스트로 null-safety 충분 검증).

## 테스트 계획
- [x] `./gradlew :querydsl-ktx:build -PspringBootVersion=3.0.13` 통과 (CI-equivalent)
- [x] 단위 테스트 40개 (각 함수 4-null 매트릭스)
- [ ] CI 매트릭스 (Spring Boot 3.0/3.2/3.3/3.4/3.5 + OpenFeign 6.12) 푸시 후 자동 검증

Closes #88