### PR TITLE
feat: NumberExpression Kotlin 산술 연산자 오버로드

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ querydsl-ktx/src/main/kotlin/com/querydsl/ktx/
 │   ├── BooleanExpressionExtensions.kt    — and, or, eq, nullif, coalesce
 │   ├── SimpleExpressionExtensions.kt     — eq, ne, in, notIn, inChunked
 │   ├── ComparableExpressionExtensions.kt — gt, goe, lt, loe, between, reverse between, rangeTo
-│   ├── NumberExpressionExtensions.kt     — same as Comparable (separate hierarchy), includes rangeTo
+│   ├── NumberExpressionExtensions.kt     — same as Comparable (separate hierarchy), includes rangeTo, arithmetic infix (add/subtract/multiply/divide/mod), Kotlin operators (+, -, *, /, %, unary -)
 │   ├── StringExpressionExtensions.kt     — contains, startsWith, endsWith, like, matches, nullif, coalesce
 │   ├── TemporalExpressionExtensions.kt   — after, before
 │   ├── CollectionExpressionExtensions.kt — contains

--- a/docs/en/guide/extensions.md
+++ b/docs/en/guide/extensions.md
@@ -263,6 +263,24 @@ entity.total divide quantity      // total / quantity
 ```
 :::
 
+::: tip Kotlin operator overloads
+Kotlin arithmetic operators (`+`, `-`, `*`, `/`, `%`, unary `-`) are also available
+for expression building (sort, projection, computed columns). These have a
+**non-null contract** (both sides required), distinct from the null-skip infix
+forms above.
+
+```kotlin
+entity.price + 1000               // price + 1000
+entity.price * taxRate            // price * tax_rate (column ref)
+-entity.price                     // -price
+(entity.price + entity.tax) * 2   // composes with parentheses
+```
+
+Use `+` / `-` / `*` / `/` / `%` when building expressions where both operands
+are guaranteed present. Use `add` / `subtract` / etc. when either side may be
+null and you want the whole expression skipped.
+:::
+
 ### Why a separate interface?
 
 In QueryDSL's type hierarchy, `NumberExpression` does **not** extend `ComparableExpression`.
@@ -285,6 +303,13 @@ operators specifically typed for `NumberExpression`.
 | `nullif` | `NumberExpression<T>?.nullif(T?)` | `NULLIF(col, ?)` |
 | `coalesce` | `NumberExpression<T>?.coalesce(T?)` | `COALESCE(col, ?)` |
 | `rangeTo` | `NumberExpression<T>..NumberExpression<T>` | _(creates Pair for between)_ |
+| `add` | `NumberExpression<T>?.add(T?)` / `add(Expression<T>?)` | `col + ?` |
+| `subtract` | `NumberExpression<T>?.subtract(T?)` / `subtract(Expression<T>?)` | `col - ?` |
+| `multiply` | `NumberExpression<T>?.multiply(T?)` / `multiply(Expression<T>?)` | `col * ?` |
+| `divide` | `NumberExpression<T>?.divide(T?)` / `divide(Expression<T>?)` | `col / ?` |
+| `mod` | `NumberExpression<T>?.mod(T?)` / `mod(Expression<T>?)` | `col % ?` |
+| `+` / `-` / `*` / `/` / `%` | `operator NumberExpression<T>.plus/minus/times/div/rem(T \| Expression<T>)` | `col + ?` _(non-null contract)_ |
+| unary `-` | `operator NumberExpression<T>.unaryMinus()` | `-col` |
 
 ### Examples
 

--- a/docs/ko/guide/extensions.md
+++ b/docs/ko/guide/extensions.md
@@ -277,6 +277,22 @@ entity.total divide quantity      // total / quantity
 ```
 :::
 
+::: tip Kotlin 연산자 오버로드
+Kotlin 산술 연산자 (`+`, `-`, `*`, `/`, `%`, 단항 `-`)도 표현식 빌딩 (정렬,
+프로젝션, computed column) 용도로 제공됩니다. 위의 null-skip infix 형태와 달리
+**non-null 계약**입니다 (양쪽 모두 필수).
+
+```kotlin
+entity.price + 1000               // price + 1000
+entity.price * taxRate            // price * tax_rate (다른 컬럼)
+-entity.price                     // -price
+(entity.price + entity.tax) * 2   // 괄호로 결합 가능
+```
+
+양쪽이 모두 보장될 때 `+` / `-` / `*` / `/` / `%`를 사용하고, 어느 한쪽이
+null일 수 있어 표현식 자체를 건너뛰고 싶다면 `add` / `subtract` 등을 사용하세요.
+:::
+
 ### 별도 인터페이스인 이유
 
 QueryDSL의 타입 계층에서 `NumberExpression`은 `ComparableExpression`을 **확장하지 않습니다**.
@@ -299,6 +315,13 @@ QueryDSL의 타입 계층에서 `NumberExpression`은 `ComparableExpression`을 
 | `nullif` | `NumberExpression<T>?.nullif(T?)` | `NULLIF(col, ?)` |
 | `coalesce` | `NumberExpression<T>?.coalesce(T?)` | `COALESCE(col, ?)` |
 | `rangeTo` | `NumberExpression<T>..NumberExpression<T>` | _(between용 Pair 생성)_ |
+| `add` | `NumberExpression<T>?.add(T?)` / `add(Expression<T>?)` | `col + ?` |
+| `subtract` | `NumberExpression<T>?.subtract(T?)` / `subtract(Expression<T>?)` | `col - ?` |
+| `multiply` | `NumberExpression<T>?.multiply(T?)` / `multiply(Expression<T>?)` | `col * ?` |
+| `divide` | `NumberExpression<T>?.divide(T?)` / `divide(Expression<T>?)` | `col / ?` |
+| `mod` | `NumberExpression<T>?.mod(T?)` / `mod(Expression<T>?)` | `col % ?` |
+| `+` / `-` / `*` / `/` / `%` | `operator NumberExpression<T>.plus/minus/times/div/rem(T \| Expression<T>)` | `col + ?` _(non-null 계약)_ |
+| 단항 `-` | `operator NumberExpression<T>.unaryMinus()` | `-col` |
 
 ### 예제
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -118,7 +118,7 @@ Reverse `between`: value on the left, expression pair on the right — `now betw
 
 ### NumberExpressionExtensions
 
-Same API as ComparableExpressionExtensions but for `NumberExpression<T>` (which does not extend `ComparableExpression` in QueryDSL's type hierarchy). Includes `gt`, `goe`, `lt`, `loe`, `between(Pair)`, `between(ClosedRange)`, `notBetween`, `nullif`, `coalesce`, reverse `between`, and `rangeTo`. Also provides null-safe arithmetic operators `add`, `subtract`, `multiply`, `divide`, `mod` (each with value and `Expression<T>` overloads).
+Same API as ComparableExpressionExtensions but for `NumberExpression<T>` (which does not extend `ComparableExpression` in QueryDSL's type hierarchy). Includes `gt`, `goe`, `lt`, `loe`, `between(Pair)`, `between(ClosedRange)`, `notBetween`, `nullif`, `coalesce`, reverse `between`, and `rangeTo`. Also provides null-safe arithmetic infix operators `add`, `subtract`, `multiply`, `divide`, `mod` (each with value and `Expression<T>` overloads), plus Kotlin operator overloads `+`, `-`, `*`, `/`, `%`, unary `-` with a non-null contract.
 
 ```kotlin
 infix fun <T> NumberExpression<T>?.add(right: T?): NumberExpression<T>?
@@ -131,6 +131,22 @@ infix fun <T> NumberExpression<T>?.divide(right: T?): NumberExpression<T>?
 infix fun <T> NumberExpression<T>?.divide(right: Expression<T>?): NumberExpression<T>?
 infix fun <T> NumberExpression<T>?.mod(right: T?): NumberExpression<T>?
 infix fun <T> NumberExpression<T>?.mod(right: Expression<T>?): NumberExpression<T>?
+    where T : Number, T : Comparable<*>
+```
+
+```kotlin
+// Kotlin operator overloads (non-null contract; for expression building)
+operator fun <T> NumberExpression<T>.plus(right: T): NumberExpression<T>
+operator fun <T> NumberExpression<T>.plus(right: Expression<T>): NumberExpression<T>
+operator fun <T> NumberExpression<T>.minus(right: T): NumberExpression<T>
+operator fun <T> NumberExpression<T>.minus(right: Expression<T>): NumberExpression<T>
+operator fun <T> NumberExpression<T>.times(right: T): NumberExpression<T>
+operator fun <T> NumberExpression<T>.times(right: Expression<T>): NumberExpression<T>
+operator fun <T> NumberExpression<T>.div(right: T): NumberExpression<T>
+operator fun <T> NumberExpression<T>.div(right: Expression<T>): NumberExpression<T>
+operator fun <T> NumberExpression<T>.rem(right: T): NumberExpression<T>
+operator fun <T> NumberExpression<T>.rem(right: Expression<T>): NumberExpression<T>
+operator fun <T> NumberExpression<T>.unaryMinus(): NumberExpression<T>
     where T : Number, T : Comparable<*>
 ```
 

--- a/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensions.kt
+++ b/querydsl-ktx/src/main/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensions.kt
@@ -534,4 +534,139 @@ interface NumberExpressionExtensions {
     operator fun <T> NumberExpression<T>.rangeTo(
         other: NumberExpression<T>,
     ): Pair<NumberExpression<T>, NumberExpression<T>> where T : Number, T : Comparable<*> = this to other
+
+    /**
+     * Kotlin `+` operator for numeric expression building.
+     *
+     * Non-null contract: both sides must be present. For null-skip semantics
+     * in dynamic WHERE building use [add] instead.
+     *
+     * ```sql
+     * price + 1000
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.plus(right: T): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.ADD, this, Expressions.constant(right))
+
+    /**
+     * Kotlin `+` operator against another expression.
+     *
+     * ```sql
+     * price + tax
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.plus(right: Expression<T>): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.ADD, this, right)
+
+    /**
+     * Kotlin `-` operator for numeric expression building.
+     *
+     * Non-null contract: both sides must be present. For null-skip semantics
+     * use [subtract] instead.
+     *
+     * ```sql
+     * price - 100
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.minus(right: T): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.SUB, this, Expressions.constant(right))
+
+    /**
+     * Kotlin `-` operator against another expression.
+     *
+     * ```sql
+     * price - discount
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.minus(right: Expression<T>): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.SUB, this, right)
+
+    /**
+     * Kotlin `*` operator for numeric expression building.
+     *
+     * Non-null contract: both sides must be present. For null-skip semantics
+     * use [multiply] instead.
+     *
+     * ```sql
+     * price * 2
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.times(right: T): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.MULT, this, Expressions.constant(right))
+
+    /**
+     * Kotlin `*` operator against another expression.
+     *
+     * ```sql
+     * price * tax_rate
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.times(right: Expression<T>): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.MULT, this, right)
+
+    /**
+     * Kotlin `/` operator for numeric expression building.
+     *
+     * Non-null contract: both sides must be present. For null-skip semantics
+     * use [divide] instead.
+     *
+     * ```sql
+     * total / 2
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.div(right: T): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.DIV, this, Expressions.constant(right))
+
+    /**
+     * Kotlin `/` operator against another expression.
+     *
+     * ```sql
+     * total / quantity
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.div(right: Expression<T>): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.DIV, this, right)
+
+    /**
+     * Kotlin `%` operator for numeric expression building.
+     *
+     * Non-null contract: both sides must be present. For null-skip semantics
+     * use [mod] instead.
+     *
+     * ```sql
+     * id % 10
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.rem(right: T): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.MOD, this, Expressions.constant(right))
+
+    /**
+     * Kotlin `%` operator against another expression.
+     *
+     * ```sql
+     * id % shard_count
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.rem(right: Expression<T>): NumberExpression<T>
+        where T : Number, T : Comparable<*> =
+        Expressions.numberOperation(this.type, Ops.MOD, this, right)
+
+    /**
+     * Kotlin unary `-` operator for numeric expression building.
+     *
+     * ```sql
+     * -price
+     * ```
+     */
+    operator fun <T> NumberExpression<T>.unaryMinus(): NumberExpression<T>
+        where T : Number, T : Comparable<*> = this.negate()
 }

--- a/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
+++ b/querydsl-ktx/src/test/kotlin/com/querydsl/ktx/extensions/NumberExpressionExtensionsTest.kt
@@ -710,4 +710,95 @@ class NumberExpressionExtensionsTest : NumberExpressionExtensions {
         val result = nullExpr mod (null as NumberExpression<Int>?)
         assertNull(result)
     }
+
+    // ── Kotlin operator overloads (#105) ──
+
+    @Test
+    fun `plus operator - value`() {
+        val result = price + 1000
+        assertNotNull(result)
+        assertTrue(result.toString().contains("+"))
+    }
+
+    @Test
+    fun `plus operator - expression`() {
+        val result = price + minPrice
+        assertNotNull(result)
+        assertTrue(result.toString().contains("+"))
+    }
+
+    @Test
+    fun `minus operator - value`() {
+        val result = price - 100
+        assertNotNull(result)
+        assertTrue(result.toString().contains("-"))
+    }
+
+    @Test
+    fun `minus operator - expression`() {
+        val result = price - minPrice
+        assertNotNull(result)
+        assertTrue(result.toString().contains("-"))
+    }
+
+    @Test
+    fun `times operator - value`() {
+        val result = price * 2
+        assertNotNull(result)
+        assertTrue(result.toString().contains("*"))
+    }
+
+    @Test
+    fun `times operator - expression`() {
+        val result = price * minPrice
+        assertNotNull(result)
+        assertTrue(result.toString().contains("*"))
+    }
+
+    @Test
+    fun `div operator - value`() {
+        val result = price / 2
+        assertNotNull(result)
+        assertTrue(result.toString().contains("/"))
+    }
+
+    @Test
+    fun `div operator - expression`() {
+        val result = price / minPrice
+        assertNotNull(result)
+        assertTrue(result.toString().contains("/"))
+    }
+
+    @Test
+    fun `rem operator - value`() {
+        val result = price % 10
+        assertNotNull(result)
+        assertTrue(result.toString().contains("%"))
+    }
+
+    @Test
+    fun `rem operator - expression`() {
+        val result = price % minPrice
+        assertNotNull(result)
+        assertTrue(result.toString().contains("%"))
+    }
+
+    @Test
+    fun `unaryMinus operator`() {
+        val result = -price
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `arithmetic operators compose with parentheses`() {
+        val result = (price + minPrice) * 2
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `rangeTo still creates Pair when arithmetic operators in scope`() {
+        // Ensures `..` still resolves to rangeTo (Pair builder), not interpreted otherwise.
+        val result = 30000 between (price..minPrice)
+        assertNotNull(result)
+    }
 }


### PR DESCRIPTION
## 요약
- `NumberExpression<T>`에 Kotlin operator 11개 추가: `plus/minus/times/div/rem` × {value, Expression} + `unaryMinus`
- 표현식 빌딩(정렬, 프로젝션, computed column)에서 자연스러운 산술 표기 지원
- non-null 계약 — null skip 시맨틱은 #88(`add/subtract/...` infix)이 담당

## 사용 예
```kotlin
entity.price + 1000             // price + 1000
entity.price * taxRate          // price * tax_rate
-entity.price                   // -price
(entity.price + entity.tax) * 2 // 결합 가능
```

## #88과의 관계
| 트랙 | receiver/arg | 시맨틱 | 용도 |
|------|--------------|--------|------|
| #88 (infix `add` 등) | nullable | 한쪽 null이면 null 반환 | 동적 WHERE 빌딩 |
| #105 (operator `+` 등) | non-null | 양쪽 필수 | 표현식 빌딩 |

두 트랙은 동일 인터페이스(`NumberExpressionExtensions`)에 공존.

## 구현
`Expressions.numberOperation(this.type, Ops.ADD/SUB/MULT/DIV/MOD, ...)`로 QueryDSL Operation을 직접 생성. #88에서 발견한 dispatch 충돌 회피 패턴을 그대로 재사용 (operator 이름은 다르지만 일관성 유지).

`unaryMinus`는 `this.negate()` 위임 (member method라 충돌 없음).

## 검증
- [x] 단위 테스트 13개 (각 operator + 결합성 + `rangeTo` 충돌 없음 검증)
- [x] `./gradlew :querydsl-ktx:test` 통과 (단위 + 통합 테스트)
- [ ] CI 매트릭스 (Java 17/21 × Spring Boot 3.0~3.5 + OpenFeign 6.12) 푸시 후 자동 검증

## 문서
- [x] AGENTS.md: `NumberExpressionExtensions` 인터페이스 설명에 operator 추가
- [x] llms-full.txt: operator 시그니처 11개 추가
- [x] docs/en/guide/extensions.md, docs/ko/guide/extensions.md: ::: tip 박스 + 함수 테이블
- [x] KDoc: 각 operator에 SQL 매핑 + non-null 계약 명시

Closes #105