### PR TITLE
chore: v1.2.0 릴리스 준비 (버전 범프 + 문서 정합성)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,11 @@ querydsl-ktx/src/main/kotlin/com/querydsl/ktx/
 ├── Expressions.kt       ← Reified template wrappers + value wrapping + constant
 ├── CaseDsl.kt           ← CASE/WHEN Kotlin DSL (searched & simple)
 ├── extensions/          ← 8 interfaces (no state, no dependencies)
-│   ├── BooleanExpressionExtensions.kt    — and, or, eq, nullif, coalesce
+│   ├── BooleanExpressionExtensions.kt    — and, or, andAnyOf (List + vararg), orAllOf (List + vararg), eq, nullif, coalesce
 │   ├── SimpleExpressionExtensions.kt     — eq, ne, in, notIn, inChunked (with SubQueryExpression overloads for eq/in/notIn), eqAll/eqAny/neAll/neAny (Collection + SubQuery for eq*; QueryDSL 5.1.0 has no SubQuery for ne*)
 │   ├── ComparableExpressionExtensions.kt — gt, goe, lt, loe, between, reverse between, rangeTo, gt/goe/lt/loe All/Any (Collection + SubQuery)
 │   ├── NumberExpressionExtensions.kt     — same as Comparable (separate hierarchy), includes rangeTo, arithmetic infix (add/subtract/multiply/divide/mod), Kotlin operators (+, -, *, /, %, unary -), gt/goe/lt/loe All/Any (Collection; SubQuery only for gtAll/gtAny per QueryDSL 5.1.0)
-│   ├── StringExpressionExtensions.kt     — contains, startsWith, endsWith, like, matches, nullif, coalesce
+│   ├── StringExpressionExtensions.kt     — contains, startsWith, endsWith, like, notLike, likeIgnoreCase, matches, escape (LIKE ESCAPE chain), equalsIgnoreCase, notEqualsIgnoreCase, nullif, coalesce
 │   ├── TemporalExpressionExtensions.kt   — after, before
 │   ├── CollectionExpressionExtensions.kt — contains
 │   └── SubQueryExtensions.kt            — exists, notExists
@@ -45,10 +45,11 @@ querydsl-ktx/src/main/kotlin/com/querydsl/ktx/
 
 ### Documentation Site
 
-- `docs/` — MkDocs Material source files (`*.md` English, `*.ko.md` Korean)
-- `mkdocs.yml` — site configuration
-- `.github/workflows/ci.yml` — Build + test on Java 17/21 matrix
-- `.github/workflows/docs.yml` — Dokka API docs + MkDocs → GitHub Pages
+- `docs/` — VitePress source files. `docs/en/` for English, `docs/ko/` for Korean
+- `docs/.vitepress/config.ts` — global config (locales, rewrites, plugins)
+- `package.json` — npm scripts (`docs:dev`, `docs:build`, `docs:preview`)
+- `.github/workflows/ci.yml` — Build + test on Java 17/21 matrix (Spring Boot 3.0/3.2/3.3/3.4/3.5 + OpenFeign QueryDSL 6.12)
+- `.github/workflows/docs.yml` — Dokka API docs + VitePress → GitHub Pages
 
 ### Publishing
 
@@ -79,8 +80,9 @@ This contract is the core design principle. Any new extension must follow it.
 ./gradlew :querydsl-ktx:dokkaHtml      # Generate API docs
 ./gradlew publishToMavenLocal             # Publish to local Maven repo (testing)
 ./gradlew publishAndReleaseToMavenCentral # Publish to Maven Central (requires GPG + Sonatype token)
-mkdocs serve                              # Local docs preview (requires pip install mkdocs-material)
-mkdocs build                              # Build docs site
+npm run docs:dev                          # Local docs preview (VitePress)
+npm run docs:build                        # Build docs site
+npm run docs:preview                      # Preview built docs site
 ```
 
 ## Code Style
@@ -102,7 +104,8 @@ mkdocs build                              # Build docs site
 ## Conventions
 
 - Dependencies: `compileOnly` for all external libraries (user provides versions)
-- Spring Data 내부 API 의존: `Querydsl` (`o.s.d.jpa.repository.support`), `SimpleEntityPathResolver` — Spring Boot 3.0~3.4 호환 검증됨. v2.0.0(Spring Boot 4) 마이그레이션 시 검토 필요
+- Spring Data 내부 API 의존: `Querydsl` (`o.s.d.jpa.repository.support`), `SimpleEntityPathResolver` — Spring Boot 3.0~3.5 호환 검증됨. v2.0.0(Spring Boot 4) 마이그레이션 시 검토 필요
 - Pagination: `slice()` (optimistic hasNext) and `exactSlice()` (exact hasNext) return Slice, `page()` returns Page, `fetch()` returns List
-- Bulk DML: wrap in `modifying { }` for flush + clear (requires active transaction; throws `IllegalStateException` otherwise)
+- Bulk DML: wrap in `modifying { }` for flush + clear (requires active transaction; throws `com.querydsl.core.QueryException` otherwise)
+- LIKE escape: `name like pattern escape '\\'` chains to existing like/notLike/likeIgnoreCase results. Invalid receivers throw `com.querydsl.core.types.ExpressionException`
 - Naming: verb form (slice, page, fetch), not gerund (slicing, paging, fetching)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-04-30
+
+### Added
+
+- **`NumberExpression` arithmetic** — null-safe infix `add` / `subtract` /
+  `multiply` / `divide` / `mod` (each with value and `Expression<T>` overloads),
+  plus Kotlin `operator` overloads `+`, `-`, `*`, `/`, `%`, unary `-` for
+  expression building (#88, #105).
+- **`SimpleExpression` subquery comparisons** — `eq` / `in` / `notIn` overloads
+  accepting `SubQueryExpression<T>?` for null-safe subquery filters (#89).
+- **`BooleanExpression` vararg combinators** — `andAnyOf` / `orAllOf` accept
+  varargs of `BooleanExpression?` in addition to the existing `List` overloads
+  (#92).
+- **String `LIKE ESCAPE` chain** — `name like pattern escape '\\'` works on
+  `like` / `notLike` / `likeIgnoreCase` results for matching literal `%` and
+  `_` characters (#91).
+- **All / Any comparison variants** — 32 new functions across
+  `SimpleExpressionExtensions`, `ComparableExpressionExtensions`, and
+  `NumberExpressionExtensions`: `eqAll` / `eqAny` / `neAll` / `neAny` /
+  `gtAll` / `gtAny` / `goeAll` / `goeAny` / `ltAll` / `ltAny` / `loeAll` /
+  `loeAny`. Each pairs `CollectionExpression<*, in T>?` with
+  `SubQueryExpression<T>?` where the QueryDSL 5.1.0 member exists. The
+  `NumberExpression` SubQuery coverage is asymmetric per QueryDSL itself
+  (`gtAll` / `gtAny` only) (#90).
+
+### Changed
+
+- **Exception types unified to QueryDSL hierarchy** — `inChunked` with
+  non-positive chunk size now throws `com.querydsl.core.types.ExpressionException`
+  (was `IllegalArgumentException`); `modifying { }` outside an active
+  transaction now throws `com.querydsl.core.QueryException` (was
+  `IllegalStateException`); `escape` invoked on a non-LIKE receiver throws
+  `ExpressionException` (#91).
+- **Spring Boot 3.5 added to CI matrix** — wrappers verified across Spring
+  Boot 3.0 / 3.2 / 3.3 / 3.4 / 3.5 with both Java 17 and 21, plus OpenFeign
+  QueryDSL 6.12.
+
+### Fixed
+
+- **`QuerydslKtxAutoConfiguration`** — registration is now keyed on
+  `EntityManagerFactory` instead of `DataSource`, supporting multi-datasource
+  setups via `@Primary` selection through `SharedEntityManagerCreator`.
+
+### Documentation
+
+- Extension reference (`docs/{en,ko}/guide/extensions.md`) covers all 32 ALL/Any
+  variants, the SubQuery comparison overloads, the LIKE escape chain, and the
+  arithmetic + Kotlin operator forms with an explicit asymmetry table.
+- Dynamic queries guide expanded with Subquery, ALL/Any, LIKE escape, and
+  computed-column patterns.
+- `llms-full.txt` and `AGENTS.md` updated to reflect the new public API and
+  the VitePress documentation toolchain.
+
+[1.2.0]: https://github.com/HarryJhin/querydsl-ktx/compare/v1.1.0...v1.2.0

--- a/README.ko.md
+++ b/README.ko.md
@@ -48,7 +48,7 @@ null 파라미터는 자동으로 건너뜁니다. `Pair`를 사용한 `between`
 
 ```kotlin
 // 1. 의존성 추가
-implementation("io.github.harryjhin:querydsl-ktx-spring-boot-starter:1.1.0")
+implementation("io.github.harryjhin:querydsl-ktx-spring-boot-starter:1.2.0")
 ```
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Null parameters are automatically skipped. `between` with a `Pair` handles one-s
 
 ```kotlin
 // 1. Add the dependency
-implementation("io.github.harryjhin:querydsl-ktx-spring-boot-starter:1.1.0")
+implementation("io.github.harryjhin:querydsl-ktx-spring-boot-starter:1.2.0")
 ```
 
 ```kotlin

--- a/docs/en/guide/best-practices.md
+++ b/docs/en/guide/best-practices.md
@@ -309,6 +309,52 @@ fun findActiveSales(now: LocalDateTime? = null): List<Product> =
 
 ---
 
+## Kotlin Operators for Computed Column Sort
+
+Sorting by a derived numeric value used to require a verbose
+`NumberExpression.add(...)` or a Querydsl `template`. With the Kotlin operator
+overloads on `NumberExpression`, expression building reads like ordinary
+arithmetic — no intermediate variables, no template placeholders.
+
+```kotlin
+// Sort products by gross price (price + tax) descending
+selectFrom(product)
+    .orderBy((product.price + product.tax).desc())
+    .fetch()
+
+// Top items by margin ratio
+selectFrom(product)
+    .orderBy(((product.price - product.cost) / product.cost).desc())
+    .fetch()
+```
+
+The arithmetic operators have a non-null contract — both operands must be
+non-null. Use them inside `orderBy`, `select` projections, and other places
+where the expression itself must always exist.
+
+For dynamic WHERE clauses where either side may be null, use the infix forms
+(`add`, `subtract`, `multiply`, `divide`, `mod`) which return `null` when
+either side is null:
+
+```kotlin
+where(product.price add discount gt 0)  // skipped if `discount` is null
+```
+
+::: tip
+Pair this with `SortSpec` to expose computed columns through dynamic sort:
+
+```kotlin
+private val productSort = sortSpec {
+    "grossPrice" by (product.price + product.tax)
+    "margin" by ((product.price - product.cost) / product.cost)
+}
+```
+
+Now `?sort=grossPrice,desc` works without changing the controller layer.
+:::
+
+---
+
 ## Putting It All Together
 
 A complete repository combining all the patterns above:

--- a/docs/en/guide/dynamic-queries.md
+++ b/docs/en/guide/dynamic-queries.md
@@ -300,6 +300,117 @@ vip = true OR (age >= ? AND active = true)
 
 :::
 
+### vararg overloads
+
+`andAnyOf` and `orAllOf` also accept a vararg of `BooleanExpression?` for terser
+inline use without `listOf(...)`:
+
+```kotlin
+predicate.andAnyOf(
+    entity.role eq role,
+    entity.department eq department,
+)
+```
+
+Identical null-skip semantics: each null predicate is dropped before the OR/AND
+group is built.
+
+---
+
+## Subquery Comparisons
+
+`SimpleExpression` supports null-safe comparison with subqueries built via
+`JPAExpressions`. Pass `null` to skip the predicate entirely.
+
+::: code-group
+
+```kotlin [Kotlin]
+import com.querydsl.jpa.JPAExpressions
+
+fun search(matchMaxPrice: Boolean): List<Product> {
+    val maxPrice = if (matchMaxPrice)
+        JPAExpressions.select(product.price.max()).from(product)
+    else null
+    return selectFrom(product)
+        .where(product.price eq maxPrice)  // null subquery -> skipped
+        .fetch()
+}
+```
+
+```sql [SQL]
+-- when maxPrice subquery is provided
+SELECT * FROM product WHERE price = (SELECT MAX(price) FROM product)
+
+-- when maxPrice subquery is null
+SELECT * FROM product
+```
+
+:::
+
+`eq`, `in`, `notIn` accept `SubQueryExpression<T>?`. The same null-skip rule
+applies as with value/expression overloads.
+
+## ALL / ANY Comparisons
+
+For comparing against multiple subquery rows or collection elements, use
+`*All` / `*Any` variants:
+
+::: code-group
+
+```kotlin [Kotlin]
+// Greater than ALL prices in a category — strictly more expensive than every item
+val categoryPrices = JPAExpressions.select(product.price).from(product)
+    .where(product.category.eq(targetCategory))
+selectFrom(product).where(product.price gtAll categoryPrices).fetch()
+
+// Equal to ANY of the cheap-category prices — match any cheap item's price
+val cheapPrices = JPAExpressions.select(product.price).from(product)
+    .where(product.price.lt(threshold))
+selectFrom(product).where(product.price eqAny cheapPrices).fetch()
+```
+
+```sql [SQL]
+SELECT * FROM product WHERE price > ALL (SELECT price FROM product WHERE category = ?)
+SELECT * FROM product WHERE price = ANY (SELECT price FROM product WHERE price < ?)
+```
+
+:::
+
+Available variants: `eqAll`/`eqAny`, `neAll`/`neAny` (Collection only),
+`gtAll`/`gtAny`, `goeAll`/`goeAny`, `ltAll`/`ltAny`, `loeAll`/`loeAny`. See the
+[All/Any asymmetry table](./extensions.md#numberexpressionextensions) for the
+exact coverage on `NumberExpression`.
+
+## LIKE with ESCAPE
+
+For patterns that need to match literal `%` or `_` characters, chain `escape`
+on a `like` / `notLike` / `likeIgnoreCase` result:
+
+```kotlin
+entity.name like "10\\%off" escape '\\'  // matches the literal "10%off"
+```
+
+The escape character is preserved through `notLike` and `likeIgnoreCase` chains.
+Invalid receivers (e.g. `escape` on a non-LIKE expression) throw
+`com.querydsl.core.types.ExpressionException`.
+
+## Arithmetic in Computed Columns
+
+`NumberExpression` exposes both null-safe infix arithmetic
+(`add`/`subtract`/`multiply`/`divide`/`mod`) and Kotlin operators (`+`, `-`,
+`*`, `/`, `%`, unary `-`). The infix forms skip when either side is null;
+operators have a non-null contract for use in projections and `orderBy`:
+
+```kotlin
+// Sort by a computed column without intermediate variables
+selectFrom(entity)
+    .orderBy((entity.price + entity.tax).desc())
+    .fetch()
+
+// Null-safe in dynamic WHERE
+where(entity.discount add bonus gt 0)  // skipped if `bonus` is null
+```
+
 ---
 
 ## Building Conditions Incrementally

--- a/docs/ko/guide/best-practices.md
+++ b/docs/ko/guide/best-practices.md
@@ -308,6 +308,52 @@ fun findActiveSales(now: LocalDateTime? = null): List<Product> =
 
 ---
 
+## Computed Column 정렬을 위한 Kotlin 연산자
+
+파생 숫자 값으로 정렬할 때, 기존에는 `NumberExpression.add(...)`나 Querydsl
+`template`이 필요했습니다. `NumberExpression`의 Kotlin operator 오버로드를
+쓰면 표현식 빌딩이 일반 산술처럼 읽힙니다. 중간 변수도, template placeholder도
+필요 없습니다.
+
+```kotlin
+// 총 가격(price + tax) 내림차순 정렬
+selectFrom(product)
+    .orderBy((product.price + product.tax).desc())
+    .fetch()
+
+// 마진 비율 상위 정렬
+selectFrom(product)
+    .orderBy(((product.price - product.cost) / product.cost).desc())
+    .fetch()
+```
+
+산술 연산자는 non-null 계약입니다. 양쪽 피연산자 모두 non-null이어야 합니다.
+`orderBy`, `select` projection 등 표현식 자체가 항상 존재해야 하는 곳에
+사용하세요.
+
+어느 한쪽이 null일 수 있는 동적 WHERE에서는 infix 형태(`add`, `subtract`,
+`multiply`, `divide`, `mod`)를 사용합니다. 양쪽 중 하나가 null이면 `null`을
+반환합니다.
+
+```kotlin
+where(product.price add discount gt 0)  // discount가 null이면 건너뜀
+```
+
+::: tip
+`SortSpec`과 함께 사용하면 동적 정렬에서 computed column을 노출할 수 있습니다.
+
+```kotlin
+private val productSort = sortSpec {
+    "grossPrice" by (product.price + product.tax)
+    "margin" by ((product.price - product.cost) / product.cost)
+}
+```
+
+이제 컨트롤러 레이어 변경 없이 `?sort=grossPrice,desc`가 동작합니다.
+:::
+
+---
+
 ## 전체 조합 예제
 
 위 패턴을 모두 결합한 완성된 리포지토리:

--- a/docs/ko/guide/dynamic-queries.md
+++ b/docs/ko/guide/dynamic-queries.md
@@ -300,6 +300,116 @@ vip = true OR (age >= ? AND active = true)
 
 :::
 
+### vararg 오버로드
+
+`andAnyOf`와 `orAllOf`는 `BooleanExpression?`의 vararg도 받습니다. `listOf(...)`
+없이 인라인으로 더 간결하게 사용할 수 있습니다.
+
+```kotlin
+predicate.andAnyOf(
+    entity.role eq role,
+    entity.department eq department,
+)
+```
+
+null-skip 시맨틱은 동일합니다. 각 null predicate는 OR/AND 그룹 빌드 전에
+제거됩니다.
+
+---
+
+## 서브쿼리 비교
+
+`SimpleExpression`은 `JPAExpressions`로 만든 서브쿼리와의 null-safe 비교를
+지원합니다. `null`을 전달하면 조건 자체가 건너뛰어집니다.
+
+::: code-group
+
+```kotlin [Kotlin]
+import com.querydsl.jpa.JPAExpressions
+
+fun search(matchMaxPrice: Boolean): List<Product> {
+    val maxPrice = if (matchMaxPrice)
+        JPAExpressions.select(product.price.max()).from(product)
+    else null
+    return selectFrom(product)
+        .where(product.price eq maxPrice)  // null 서브쿼리 -> 건너뜀
+        .fetch()
+}
+```
+
+```sql [SQL]
+-- maxPrice 서브쿼리가 제공된 경우
+SELECT * FROM product WHERE price = (SELECT MAX(price) FROM product)
+
+-- maxPrice 서브쿼리가 null인 경우
+SELECT * FROM product
+```
+
+:::
+
+`eq`, `in`, `notIn`은 `SubQueryExpression<T>?`를 받습니다. 값/표현식 오버로드와
+동일한 null-skip 규칙이 적용됩니다.
+
+## ALL / Any 비교
+
+여러 서브쿼리 행 또는 컬렉션 원소와 비교하려면 `*All` / `*Any` 변형을 사용합니다.
+
+::: code-group
+
+```kotlin [Kotlin]
+// 카테고리의 모든 가격보다 큰 — 해당 카테고리의 모든 상품보다 비싼 상품
+val categoryPrices = JPAExpressions.select(product.price).from(product)
+    .where(product.category.eq(targetCategory))
+selectFrom(product).where(product.price gtAll categoryPrices).fetch()
+
+// cheap 카테고리의 어떤 가격과도 일치 — 어떤 cheap 상품의 가격과 같은 상품
+val cheapPrices = JPAExpressions.select(product.price).from(product)
+    .where(product.price.lt(threshold))
+selectFrom(product).where(product.price eqAny cheapPrices).fetch()
+```
+
+```sql [SQL]
+SELECT * FROM product WHERE price > ALL (SELECT price FROM product WHERE category = ?)
+SELECT * FROM product WHERE price = ANY (SELECT price FROM product WHERE price < ?)
+```
+
+:::
+
+지원 변형: `eqAll`/`eqAny`, `neAll`/`neAny` (Collection만), `gtAll`/`gtAny`,
+`goeAll`/`goeAny`, `ltAll`/`ltAny`, `loeAll`/`loeAny`. `NumberExpression`의
+정확한 커버리지는
+[All/Any 비대칭 표](./extensions.md#numberexpressionextensions)를 참고하세요.
+
+## ESCAPE를 사용한 LIKE
+
+`%` 또는 `_` 문자를 리터럴로 매칭해야 하는 패턴에서는 `like` / `notLike` /
+`likeIgnoreCase` 결과에 `escape`를 체이닝합니다.
+
+```kotlin
+entity.name like "10\\%off" escape '\\'  // 리터럴 "10%off"와 매칭
+```
+
+이스케이프 문자는 `notLike`, `likeIgnoreCase` 체인에서도 그대로 유지됩니다.
+유효하지 않은 receiver(LIKE가 아닌 표현식 등)에는
+`com.querydsl.core.types.ExpressionException`이 발생합니다.
+
+## Computed Column에서의 산술
+
+`NumberExpression`은 null-safe infix 산술
+(`add`/`subtract`/`multiply`/`divide`/`mod`)과 Kotlin 연산자 (`+`, `-`, `*`,
+`/`, `%`, 단항 `-`) 양쪽을 제공합니다. infix는 양쪽 중 하나가 null이면
+건너뛰고, 연산자는 non-null 계약이라 projection이나 `orderBy`에 적합합니다.
+
+```kotlin
+// 중간 변수 없이 computed column으로 정렬
+selectFrom(entity)
+    .orderBy((entity.price + entity.tax).desc())
+    .fetch()
+
+// 동적 WHERE에서 null-safe
+where(entity.discount add bonus gt 0)  // bonus가 null이면 건너뜀
+```
+
 ---
 
 ## 조건을 점진적으로 구성하기

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.0
+version=1.2.0

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -34,10 +34,10 @@ Each optional filter adds 1-3 lines. Range filters need 3 branches. querydsl-ktx
 
 ```kotlin
 // Gradle Kotlin DSL — starter (includes AutoConfiguration for JPAQueryFactory)
-implementation("io.github.harryjhin:querydsl-ktx-spring-boot-starter:1.1.0")
+implementation("io.github.harryjhin:querydsl-ktx-spring-boot-starter:1.2.0")
 
 // Or core only (extension interfaces + QuerydslRepository, no auto-config)
-implementation("io.github.harryjhin:querydsl-ktx:1.1.0")
+implementation("io.github.harryjhin:querydsl-ktx:1.2.0")
 ```
 
 ## Core Concept


### PR DESCRIPTION
## 요약
v1.2.0 릴리스를 위한 마무리 작업: 버전 범프 + AGENTS.md stale 정보 정정 + 신규 API 가이드 보강 + CHANGELOG 신규.

## 버전 범프 (1.1.0 → 1.2.0)
- gradle.properties
- README.md / README.ko.md 의존성 좌표
- llms-full.txt 의존성 좌표 (2곳)

## AGENTS.md stale 정보 정정 (BLOCKER급)
v1.2.0 직전 ultrathink 검토에서 발견:
| 항목 | Before | After |
|---|---|---|
| BooleanExpressionExtensions 함수 목록 | `and, or, eq, nullif, coalesce` | + `andAnyOf (List + vararg)`, `orAllOf (List + vararg)` |
| StringExpressionExtensions 함수 목록 | `contains, startsWith, ..., nullif, coalesce` | + `escape`, `likeIgnoreCase`, `notLike`, `equalsIgnoreCase` 등 |
| 문서 빌드 시스템 | MkDocs Material + `mkdocs.yml` | **VitePress** + `docs/.vitepress/config.ts` + `package.json` |
| 빌드 명령 | `mkdocs serve` / `mkdocs build` | `npm run docs:dev` / `docs:build` / `docs:preview` |
| Spring Boot 호환 | 3.0~3.4 | 3.0~3.5 (CI 매트릭스 5종) |
| 예외 타입 (`modifying`) | `IllegalStateException` | `com.querydsl.core.QueryException` (PR #104 통일) |

→ AGENTS.md는 LLM 에이전트가 사용하는 진실의 원천(SoT). v1.2.0 릴리스 전 정정 필수.

## 문서 보강
### dynamic-queries.md (EN/KO)
v1.2.0 신규 API 사용 패턴 5종 추가:
- **vararg overloads** — `andAnyOf` / `orAllOf` vararg 변형 (PR #102)
- **Subquery comparisons** — `eq` / `in` / `notIn` × `SubQueryExpression<T>?` (PR #108)
- **ALL / Any comparisons** — `eqAll` / `gtAny` 등 ALL/Any 32 변형 (PR #109) + 비대칭 표 링크
- **LIKE with ESCAPE** — `like pattern escape '\\'` chain (PR #104)
- **Computed column arithmetic** — Kotlin 연산자 (`+`, `-`, ...) 표현식 빌딩 + infix `add`/`subtract` 동적 WHERE (PR #106, #107)

### best-practices.md (EN/KO)
신규 best practice 1개 추가:
- **Computed column 정렬을 위한 Kotlin 연산자** — `(price + tax).desc()` 스타일 정렬, `SortSpec`과 결합한 동적 정렬 노출 패턴

### CHANGELOG.md (신규)
Keep a Changelog 포맷으로 v1.2.0 변경사항 정리:
- Added: 산술, SubQuery 비교, vararg, escape, ALL/Any (이슈 #88, #89, #90, #91, #92, #105 → PR #102, #104, #106, #107, #108, #109)
- Changed: 예외 타입 통일 (`ExpressionException`, `QueryException`), Spring Boot 3.5 CI 매트릭스 추가
- Fixed: `QuerydslKtxAutoConfiguration` `EntityManagerFactory` 기반 등록 (multi-datasource 지원)
- Documentation: extensions / dynamic-queries / llms-full / AGENTS 갱신

## 검증
- [x] `./gradlew :querydsl-ktx:test` 통과
- [x] 모든 stale 참조 (`1.1.0`, `mkdocs`, `IllegalStateException`, `3.0~3.4`) grep 0건
- [ ] CI 매트릭스 12종 푸시 후 자동 검증

## 머지 후 액션
1. `git tag v1.2.0`
2. `git push origin v1.2.0`
3. `gh release create v1.2.0 --generate-notes` (release.yml 자동 분류)